### PR TITLE
Pass tests on Windows;

### DIFF
--- a/src/SchemaGenerator/CodeGenerator/CodeFile/AbstractCodeFile.php
+++ b/src/SchemaGenerator/CodeGenerator/CodeFile/AbstractCodeFile.php
@@ -69,8 +69,8 @@ abstract class AbstractCodeFile implements CodeFileInterface
         $fileContents = $this->generateFileContents();
 
         $filePath = $this->writeDir;
-        if (substr($filePath, -1) !== '/') {
-            $filePath .= '/';
+        if (substr($filePath, -1) !== DIRECTORY_SEPARATOR) {
+            $filePath .= DIRECTORY_SEPARATOR;
         }
         $filePath .= $this->fileName . '.php';
 
@@ -138,6 +138,6 @@ abstract class AbstractCodeFile implements CodeFileInterface
      */
     public function getWritePath(): string
     {
-        return $this->writeDir . "/$this->fileName.php";
+        return $this->writeDir . DIRECTORY_SEPARATOR . $this->fileName . ".php";
     }
 }

--- a/src/SchemaGenerator/SchemaClassGenerator.php
+++ b/src/SchemaGenerator/SchemaClassGenerator.php
@@ -295,7 +295,7 @@ class SchemaClassGenerator
             $currentDir = dirname($currentDir);
         }
 
-        $this->writeDir = $currentDir . '/schema_object';
+        $this->writeDir = $currentDir . DIRECTORY_SEPARATOR .'schema_object';
     }
 
     /**

--- a/tests/AbstractCodeFileTest.php
+++ b/tests/AbstractCodeFileTest.php
@@ -61,12 +61,20 @@ class AbstractCodeFileTest extends CodeFileTestCase
     /**
      * @testdox Test the behavior of the constructor when provided with a non-writable directory
      *
-     * @requires OSFAMILY BSD|Darwin|Solaris|Linux|unknown
      * @covers \GraphQL\SchemaGenerator\CodeGenerator\CodeFile\AbstractCodeFile::__construct()
      * @covers \GraphQL\SchemaGenerator\CodeGenerator\CodeFile\AbstractCodeFile::validateDirectory
      */
     public function testUnwritableDirInConstructor()
     {
+
+        $uname = strtolower(php_uname());
+
+        if (strpos($uname, "darwin") !== false) {
+            // It's OSX
+        }
+        elseif (strpos($uname, "win") !== false) {
+            $this->markTestSkipped('Skipped on WIN');
+        }
 
         $testDir = static::getGeneratedFilesDir() . DIRECTORY_SEPARATOR . 'unwritable-constructor';
         mkdir($testDir);
@@ -97,12 +105,20 @@ class AbstractCodeFileTest extends CodeFileTestCase
     /**
      * @testdox Test the behavior of changeWriteDir method when provided with a non-writable directory
      *
-     * @requires OSFAMILY BSD|Darwin|Solaris|Linux|unknown
      * @covers \GraphQL\SchemaGenerator\CodeGenerator\CodeFile\AbstractCodeFile::changeWriteDir
      * @covers \GraphQL\SchemaGenerator\CodeGenerator\CodeFile\AbstractCodeFile::validateDirectory
      */
     public function testUnwritableDir()
     {
+        $uname = strtolower(php_uname());
+
+        if (strpos($uname, "darwin") !== false) {
+            // It's OSX
+        }
+        elseif (strpos($uname, "win") !== false) {
+            $this->markTestSkipped('Skipped on WIN');
+        }
+
         $testDir = static::getGeneratedFilesDir() . DIRECTORY_SEPARATOR .'unwritable';
         mkdir($testDir);
         chmod($testDir, 0444);

--- a/tests/AbstractCodeFileTest.php
+++ b/tests/AbstractCodeFileTest.php
@@ -26,7 +26,7 @@ class AbstractCodeFileTest extends CodeFileTestCase
      */
     protected static function getExpectedFilesDir()
     {
-        return parent::getExpectedFilesDir() . '/abstract_code_files';
+        return parent::getExpectedFilesDir() . DIRECTORY_SEPARATOR . 'abstract_code_files';
     }
 
     /**
@@ -39,7 +39,7 @@ class AbstractCodeFileTest extends CodeFileTestCase
             AbstractCodeFile::class,
             [static::getGeneratedFilesDir(), $this->fileName]
         );
-        $this->codeFile->method('generateFileContents')->willReturn("<?php\n");
+        $this->codeFile->method('generateFileContents')->willReturn("<?php" . PHP_EOL);
     }
 
     /**
@@ -53,29 +53,32 @@ class AbstractCodeFileTest extends CodeFileTestCase
         $this->expectException(\Exception::class);
         $mock = $this->getMockForAbstractClass(
             AbstractCodeFile::class,
-            [static::getGeneratedFilesDir() . '/invalid', $this->fileName]
+            [static::getGeneratedFilesDir() . DIRECTORY_SEPARATOR . 'invalid', $this->fileName]
         );
-        $mock->method('generateFileContents')->willReturn("<?php\n");
+        $mock->method('generateFileContents')->willReturn("<?php" . PHP_EOL);
     }
 
     /**
      * @testdox Test the behavior of the constructor when provided with a non-writable directory
      *
+     * @requires OS ^Windows
      * @covers \GraphQL\SchemaGenerator\CodeGenerator\CodeFile\AbstractCodeFile::__construct()
      * @covers \GraphQL\SchemaGenerator\CodeGenerator\CodeFile\AbstractCodeFile::validateDirectory
      */
     public function testUnwritableDirInConstructor()
     {
-        $testDir = static::getGeneratedFilesDir() . '/unwritable-constructor';
+
+        $testDir = static::getGeneratedFilesDir() . DIRECTORY_SEPARATOR . 'unwritable-constructor';
         mkdir($testDir);
         chmod($testDir, 0444);
 
         $this->expectException(\Exception::class);
+
         $mock = $this->getMockForAbstractClass(
             AbstractCodeFile::class,
             [$testDir, $this->fileName]
         );
-        $mock->method('generateFileContents')->willReturn("<?php\n");
+        $mock->method('generateFileContents')->willReturn("<?php" . PHP_EOL);
     }
 
     /**
@@ -86,19 +89,21 @@ class AbstractCodeFileTest extends CodeFileTestCase
      */
     public function testInvalidWriteDir()
     {
+
         $this->expectException(\Exception::class);
-        $this->codeFile->changeWriteDir(static::getGeneratedFilesDir() . '/invalid');
+        $this->codeFile->changeWriteDir(static::getGeneratedFilesDir() . DIRECTORY_SEPARATOR . 'invalid');
     }
 
     /**
      * @testdox Test the behavior of changeWriteDir method when provided with a non-writable directory
      *
+     * @requires OS ^Windows
      * @covers \GraphQL\SchemaGenerator\CodeGenerator\CodeFile\AbstractCodeFile::changeWriteDir
      * @covers \GraphQL\SchemaGenerator\CodeGenerator\CodeFile\AbstractCodeFile::validateDirectory
      */
     public function testUnwritableDir()
     {
-        $testDir = static::getGeneratedFilesDir() . '/unwritable';
+        $testDir = static::getGeneratedFilesDir() . DIRECTORY_SEPARATOR .'unwritable';
         mkdir($testDir);
         chmod($testDir, 0444);
 
@@ -111,7 +116,7 @@ class AbstractCodeFileTest extends CodeFileTestCase
      */
     public function testWritePathGetter()
     {
-        $this->assertEquals(static::getGeneratedFilesDir() . "/$this->fileName.php", $this->codeFile->getWritePath());
+        $this->assertEquals(static::getGeneratedFilesDir() . DIRECTORY_SEPARATOR . $this->fileName . ".php", $this->codeFile->getWritePath());
     }
 
     /**
@@ -124,7 +129,13 @@ class AbstractCodeFileTest extends CodeFileTestCase
     public function testFileWritingWorks()
     {
         $this->codeFile->writeFile();
-        $this->assertFileEquals(static::getExpectedFilesDir() . "/$this->fileName.php", $this->codeFile->getWritePath());
+
+        $this->assertTrue(
+            $this->assertFileEqualsIgnoreWhitespace(
+                static::getExpectedFilesDir() . DIRECTORY_SEPARATOR . $this->fileName . ".php", $this->codeFile->getWritePath()
+            )
+        );
+
     }
 
     /**
@@ -137,10 +148,14 @@ class AbstractCodeFileTest extends CodeFileTestCase
     public function testFileWritingWorksWithTrailingSlash()
     {
         $this->fileName = 'EmptyCodeFileWithSlash';
-        $this->codeFile->changeWriteDir($this->codeFile->getWriteDir() . '/');
+        $this->codeFile->changeWriteDir($this->codeFile->getWriteDir() . DIRECTORY_SEPARATOR);
         $this->codeFile->changeFileName($this->fileName);
         $this->codeFile->writeFile();
 
-        $this->assertFileEquals(static::getExpectedFilesDir() . "/$this->fileName.php", $this->codeFile->getWritePath());
+        $this->assertTrue(
+            $this->assertFileEqualsIgnoreWhitespace(
+                static::getExpectedFilesDir() . DIRECTORY_SEPARATOR . $this->fileName . ".php", $this->codeFile->getWritePath()
+            )
+        );
     }
 }

--- a/tests/AbstractCodeFileTest.php
+++ b/tests/AbstractCodeFileTest.php
@@ -61,7 +61,7 @@ class AbstractCodeFileTest extends CodeFileTestCase
     /**
      * @testdox Test the behavior of the constructor when provided with a non-writable directory
      *
-     * @requires OS ^Windows
+     * @requires OSFAMILY BSD|Darwin|Solaris|Linux|unknown
      * @covers \GraphQL\SchemaGenerator\CodeGenerator\CodeFile\AbstractCodeFile::__construct()
      * @covers \GraphQL\SchemaGenerator\CodeGenerator\CodeFile\AbstractCodeFile::validateDirectory
      */
@@ -97,7 +97,7 @@ class AbstractCodeFileTest extends CodeFileTestCase
     /**
      * @testdox Test the behavior of changeWriteDir method when provided with a non-writable directory
      *
-     * @requires OS ^Windows
+     * @requires OSFAMILY BSD|Darwin|Solaris|Linux|unknown
      * @covers \GraphQL\SchemaGenerator\CodeGenerator\CodeFile\AbstractCodeFile::changeWriteDir
      * @covers \GraphQL\SchemaGenerator\CodeGenerator\CodeFile\AbstractCodeFile::validateDirectory
      */

--- a/tests/ArgumentsObjectClassBuilderTest.php
+++ b/tests/ArgumentsObjectClassBuilderTest.php
@@ -19,7 +19,7 @@ class ArgumentsObjectClassBuilderTest extends CodeFileTestCase
      */
     protected static function getExpectedFilesDir()
     {
-        return parent::getExpectedFilesDir() . '/arguments_objects';
+        return parent::getExpectedFilesDir() . DIRECTORY_SEPARATOR . 'arguments_objects';
     }
 
     /**
@@ -38,9 +38,11 @@ class ArgumentsObjectClassBuilderTest extends CodeFileTestCase
         $classBuilder->addScalarArgument('scalarProperty');
         $classBuilder->build();
 
-        $this->assertFileEquals(
-            static::getExpectedFilesDir() . "/$objectName.php",
-            static::getGeneratedFilesDir() . "/$objectName.php"
+        $this->assertTrue(
+            $this->assertFileEqualsIgnoreWhitespace(
+            static::getExpectedFilesDir() . DIRECTORY_SEPARATOR . $objectName . ".php",
+            static::getGeneratedFilesDir() . DIRECTORY_SEPARATOR . $objectName . ".php"
+            )
         );
     }
 
@@ -61,9 +63,11 @@ class ArgumentsObjectClassBuilderTest extends CodeFileTestCase
         $classBuilder->addScalarArgument('another_scalar_property');
         $classBuilder->build();
 
-        $this->assertFileEquals(
-            static::getExpectedFilesDir() . "/$objectName.php",
-            static::getGeneratedFilesDir() . "/$objectName.php"
+        $this->assertTrue(
+            $this->assertFileEqualsIgnoreWhitespace(
+                static::getExpectedFilesDir() . DIRECTORY_SEPARATOR . $objectName . ".php",
+                static::getGeneratedFilesDir() . DIRECTORY_SEPARATOR . $objectName . ".php"
+            )
         );
     }
 
@@ -83,9 +87,11 @@ class ArgumentsObjectClassBuilderTest extends CodeFileTestCase
         $classBuilder->addListArgument('listProperty', 'string');
         $classBuilder->build();
 
-        $this->assertFileEquals(
-            static::getExpectedFilesDir() . "/$objectName.php",
-            static::getGeneratedFilesDir() . "/$objectName.php"
+        $this->assertTrue(
+            $this->assertFileEqualsIgnoreWhitespace(
+                static::getExpectedFilesDir() . DIRECTORY_SEPARATOR . $objectName . ".php",
+                static::getGeneratedFilesDir() . DIRECTORY_SEPARATOR . $objectName . ".php"
+            )
         );
     }
 
@@ -106,9 +112,11 @@ class ArgumentsObjectClassBuilderTest extends CodeFileTestCase
         $classBuilder->addListArgument('another_list_property', 'string');
         $classBuilder->build();
 
-        $this->assertFileEquals(
-            static::getExpectedFilesDir() . "/$objectName.php",
-            static::getGeneratedFilesDir() . "/$objectName.php"
+        $this->assertTrue(
+            $this->assertFileEqualsIgnoreWhitespace(
+                static::getExpectedFilesDir() . DIRECTORY_SEPARATOR . $objectName . ".php",
+                static::getGeneratedFilesDir() . DIRECTORY_SEPARATOR . $objectName . ".php"
+            )
         );
     }
 
@@ -128,9 +136,11 @@ class ArgumentsObjectClassBuilderTest extends CodeFileTestCase
         $classBuilder->addInputObjectArgument('objectProperty', 'Some');
         $classBuilder->build();
 
-        $this->assertFileEquals(
-            static::getExpectedFilesDir() . "/$objectName.php",
-            static::getGeneratedFilesDir() . "/$objectName.php"
+        $this->assertTrue(
+            $this->assertFileEqualsIgnoreWhitespace(
+                static::getExpectedFilesDir() . DIRECTORY_SEPARATOR . $objectName . ".php",
+                static::getGeneratedFilesDir() . DIRECTORY_SEPARATOR . $objectName . ".php"
+            )
         );
     }
 
@@ -151,9 +161,11 @@ class ArgumentsObjectClassBuilderTest extends CodeFileTestCase
         $classBuilder->addInputObjectArgument('another_object_property', 'Another');
         $classBuilder->build();
 
-        $this->assertFileEquals(
-            static::getExpectedFilesDir() . "/$objectName.php",
-            static::getGeneratedFilesDir() . "/$objectName.php"
+        $this->assertTrue(
+            $this->assertFileEqualsIgnoreWhitespace(
+                static::getExpectedFilesDir() . DIRECTORY_SEPARATOR . $objectName . ".php",
+                static::getGeneratedFilesDir() . DIRECTORY_SEPARATOR . $objectName . ".php"
+            )
         );
     }
 }

--- a/tests/ClassFileTest.php
+++ b/tests/ClassFileTest.php
@@ -11,7 +11,7 @@ class ClassFileTest extends CodeFileTestCase
      */
     protected static function getExpectedFilesDir()
     {
-        return parent::getExpectedFilesDir() . '/classes';
+        return parent::getExpectedFilesDir() . DIRECTORY_SEPARATOR . 'classes';
     }
 
     /**
@@ -26,7 +26,11 @@ class ClassFileTest extends CodeFileTestCase
         $class = new ClassFile(static::getGeneratedFilesDir(), $fileName);
         $class->writeFile();
 
-        $this->assertFileEquals(static::getExpectedFilesDir() . "/$fileName.php", $class->getWritePath());
+        $this->assertTrue(
+            $this->assertFileEqualsIgnoreWhitespace(
+                static::getExpectedFilesDir() . DIRECTORY_SEPARATOR . $fileName . ".php", $class->getWritePath()
+            )
+        );
 
         return $class;
     }
@@ -46,7 +50,11 @@ class ClassFileTest extends CodeFileTestCase
         $class->extendsClass('Base');
         $class->writeFile();
 
-        $this->assertFileEquals(static::getExpectedFilesDir() . "/$fileName.php", $class->getWritePath());
+        $this->assertTrue(
+            $this->assertFileEqualsIgnoreWhitespace(
+                static::getExpectedFilesDir() . DIRECTORY_SEPARATOR . $fileName . ".php", $class->getWritePath()
+            )
+        );
     }
 
     /**
@@ -58,9 +66,13 @@ class ClassFileTest extends CodeFileTestCase
     {
         $class->extendsClass('');
         $class->writeFile();
-
         $fileName = $class->getFileName();
-        $this->assertFileEquals(static::getExpectedFilesDir() . "/$fileName.php", $class->getWritePath());
+
+        $this->assertTrue(
+            $this->assertFileEqualsIgnoreWhitespace(
+                static::getExpectedFilesDir() . DIRECTORY_SEPARATOR . $fileName . ".php", $class->getWritePath()
+            )
+        );
     }
 
     /**
@@ -78,14 +90,22 @@ class ClassFileTest extends CodeFileTestCase
         $class->implementsInterface('InterfaceOne');
         $class->writeFile();
 
-        $this->assertFileEquals(static::getExpectedFilesDir() . "/$fileName.php", $class->getWritePath());
+        $this->assertTrue(
+            $this->assertFileEqualsIgnoreWhitespace(
+                static::getExpectedFilesDir() . DIRECTORY_SEPARATOR . $fileName . ".php", $class->getWritePath()
+            )
+        );
 
         $fileName = 'ClassImplementsMultipleInterfaces';
         $class->changeFileName($fileName);
         $class->implementsInterface('InterfaceTwo');
         $class->writeFile();
 
-        $this->assertFileEquals(static::getExpectedFilesDir() . "/$fileName.php", $class->getWritePath());
+        $this->assertTrue(
+            $this->assertFileEqualsIgnoreWhitespace(
+                static::getExpectedFilesDir() . DIRECTORY_SEPARATOR . $fileName . ".php", $class->getWritePath()
+            )
+        );
 
         return $class;
     }
@@ -103,7 +123,12 @@ class ClassFileTest extends CodeFileTestCase
         $class->writeFile();
 
         $fileName = $class->getFileName();
-        $this->assertFileEquals(static::getExpectedFilesDir() . "/$fileName.php", $class->getWritePath());
+
+        $this->assertTrue(
+            $this->assertFileEqualsIgnoreWhitespace(
+                static::getExpectedFilesDir() . DIRECTORY_SEPARATOR . $fileName . ".php", $class->getWritePath()
+            )
+        );
     }
 
     /**
@@ -117,7 +142,12 @@ class ClassFileTest extends CodeFileTestCase
         $class->writeFile();
 
         $fileName = $class->getFileName();
-        $this->assertFileEquals(static::getExpectedFilesDir() . "/$fileName.php", $class->getWritePath());
+
+        $this->assertTrue(
+            $this->assertFileEqualsIgnoreWhitespace(
+                static::getExpectedFilesDir() . DIRECTORY_SEPARATOR . $fileName . ".php", $class->getWritePath()
+            )
+        );
     }
 
     /**
@@ -135,7 +165,11 @@ class ClassFileTest extends CodeFileTestCase
         $class->addTrait('TraitOne');
         $class->writeFile();
 
-        $this->assertFileEquals(static::getExpectedFilesDir() . "/$fileName.php", $class->getWritePath());
+        $this->assertTrue(
+            $this->assertFileEqualsIgnoreWhitespace(
+                static::getExpectedFilesDir() . DIRECTORY_SEPARATOR . $fileName . ".php", $class->getWritePath()
+            )
+        );
 
         $fileName = 'ClassWithMultipleTraits';
         $class->changeFileName($fileName);
@@ -143,7 +177,11 @@ class ClassFileTest extends CodeFileTestCase
         $class->addTrait('TraitThree');
         $class->writeFile();
 
-        $this->assertFileEquals(static::getExpectedFilesDir() . "/$fileName.php", $class->getWritePath());
+        $this->assertTrue(
+            $this->assertFileEqualsIgnoreWhitespace(
+                static::getExpectedFilesDir() . DIRECTORY_SEPARATOR . $fileName . ".php", $class->getWritePath()
+            )
+        );
 
         return $class;
     }
@@ -161,7 +199,12 @@ class ClassFileTest extends CodeFileTestCase
         $class->writeFile();
 
         $fileName = $class->getFileName();
-        $this->assertFileEquals(static::getExpectedFilesDir() . "/$fileName.php", $class->getWritePath());
+
+        $this->assertTrue(
+            $this->assertFileEqualsIgnoreWhitespace(
+                static::getExpectedFilesDir() . DIRECTORY_SEPARATOR . $fileName . ".php", $class->getWritePath()
+            )
+        );
     }
 
     /**
@@ -175,7 +218,12 @@ class ClassFileTest extends CodeFileTestCase
         $class->writeFile();
 
         $fileName = $class->getFileName();
-        $this->assertFileEquals(static::getExpectedFilesDir() . "/$fileName.php", $class->getWritePath());
+
+        $this->assertTrue(
+            $this->assertFileEqualsIgnoreWhitespace(
+                static::getExpectedFilesDir() . DIRECTORY_SEPARATOR . $fileName . ".php", $class->getWritePath()
+            )
+        );
     }
 
     /**
@@ -194,7 +242,11 @@ class ClassFileTest extends CodeFileTestCase
         $class->addConstant('CONST_ONE', 'ONE');
         $class->writeFile();
 
-        $this->assertFileEquals(static::getExpectedFilesDir() . "/$fileName.php", $class->getWritePath());
+        $this->assertTrue(
+            $this->assertFileEqualsIgnoreWhitespace(
+                static::getExpectedFilesDir() . DIRECTORY_SEPARATOR . $fileName . ".php", $class->getWritePath()
+            )
+        );
 
         $fileName = 'ClassWithMultipleConstants';
         $class->changeFileName($fileName);
@@ -205,7 +257,11 @@ class ClassFileTest extends CodeFileTestCase
         $class->addConstant('CONST_SIX', 6.6);
         $class->writeFile();
 
-        $this->assertFileEquals(static::getExpectedFilesDir() . "/$fileName.php", $class->getWritePath());
+        $this->assertTrue(
+            $this->assertFileEqualsIgnoreWhitespace(
+                static::getExpectedFilesDir() . DIRECTORY_SEPARATOR . $fileName . ".php", $class->getWritePath()
+            )
+        );
 
         return $class;
     }
@@ -223,7 +279,12 @@ class ClassFileTest extends CodeFileTestCase
         $class->writeFile();
 
         $fileName = $class->getFileName();
-        $this->assertFileEquals(static::getExpectedFilesDir() . "/$fileName.php", $class->getWritePath());
+
+        $this->assertTrue(
+            $this->assertFileEqualsIgnoreWhitespace(
+                static::getExpectedFilesDir() . DIRECTORY_SEPARATOR . $fileName . ".php", $class->getWritePath()
+            )
+        );
     }
 
     /**
@@ -237,7 +298,12 @@ class ClassFileTest extends CodeFileTestCase
         $class->writeFile();
 
         $fileName = $class->getFileName();
-        $this->assertFileEquals(static::getExpectedFilesDir() . "/$fileName.php", $class->getWritePath());
+
+        $this->assertTrue(
+            $this->assertFileEqualsIgnoreWhitespace(
+                static::getExpectedFilesDir() . DIRECTORY_SEPARATOR . $fileName . ".php", $class->getWritePath()
+            )
+        );
     }
 
     /**
@@ -289,6 +355,10 @@ class ClassFileTest extends CodeFileTestCase
 }');
         $class->writeFile();
 
-        $this->assertFileEquals(static::getExpectedFilesDir() . "/$fileName.php", $class->getWritePath());
+        $this->assertTrue(
+            $this->assertFileEqualsIgnoreWhitespace(
+                static::getExpectedFilesDir() . DIRECTORY_SEPARATOR . $fileName . ".php", $class->getWritePath()
+            )
+        );
     }
 }

--- a/tests/ClientTest.php
+++ b/tests/ClientTest.php
@@ -63,7 +63,7 @@ class ClientTest extends TestCase
 
         /** @var Request $firstRequest */
         $firstRequest = $container[0]['request'];
-        $this->assertEquals('{"query":"query_string"}', $firstRequest->getBody()->getContents());
+        $this->assertEquals('{"query":"query_string","variables":{}}', $firstRequest->getBody()->getContents());
 
         /** @var Request $secondRequest */
         $secondRequest = $container[1]['request'];

--- a/tests/CodeFileTestCase.php
+++ b/tests/CodeFileTestCase.php
@@ -11,7 +11,7 @@ abstract class CodeFileTestCase extends TestCase
      */
     protected static function getGeneratedFilesDir()
     {
-        return dirname(__FILE__) . '/files_generated';
+        return dirname(__FILE__) . DIRECTORY_SEPARATOR . 'files_generated';
     }
 
     /**
@@ -19,7 +19,8 @@ abstract class CodeFileTestCase extends TestCase
      */
     protected static function getExpectedFilesDir()
     {
-        return dirname(__FILE__) . '/files_expected';
+
+        return dirname(__FILE__) . DIRECTORY_SEPARATOR . 'files_expected';
     }
 
     /**
@@ -28,7 +29,10 @@ abstract class CodeFileTestCase extends TestCase
     public static function setUpBeforeClass(): void
     {
         parent::setUpBeforeClass();
-        mkdir(static::getGeneratedFilesDir());
+
+        if ( !is_dir(static::getGeneratedFilesDir() )) {
+            mkdir(static::getGeneratedFilesDir());
+        }
     }
 
     /**
@@ -45,9 +49,10 @@ abstract class CodeFileTestCase extends TestCase
      */
     private static function removeDirRecursive($dirName)
     {
+
         foreach (scandir($dirName) as $fileName) {
             if ($fileName !== '.' && $fileName !== '..') {
-                $filePath = "$dirName/$fileName";
+                $filePath = $dirName . DIRECTORY_SEPARATOR . $fileName;
                 if (is_dir($filePath)) {
                     static::removeDirRecursive($filePath);
                 } else {
@@ -55,6 +60,54 @@ abstract class CodeFileTestCase extends TestCase
                 }
             }
         }
-        rmdir($dirName);
+
+        @rmdir($dirName);
     }
+
+    /**
+     * Read file content ignoring whitespace characters
+     * @param $filename
+     * @return string
+     */
+    private function readFileContent($filename) {
+
+        $content = file_get_contents($filename);
+
+        if (!$content) {
+            return '';
+        }
+
+        return str_replace(["\t","\n","\r","\0","\x0B"],'', $content );
+    }
+
+    /**
+     * Compare files by content
+     * @param $expectedFile
+     * @param $actualFile
+     * @return bool
+     */
+    public function assertFileEqualsIgnoreWhitespace($expectedFile, $actualFile ) {
+
+        $expected = $this->readFileContent($expectedFile);
+
+        if (empty($expected)) {
+            return false;
+        }
+
+        $generated = $this->readFileContent($actualFile);
+
+        if (empty($generated)) {
+            return false;
+        }
+
+        if (strcmp($expected, $generated) !== 0) {
+            return false;
+        }
+
+        return true;
+
+    }
+
+
+
 }

--- a/tests/EnumObjectBuilderTest.php
+++ b/tests/EnumObjectBuilderTest.php
@@ -20,7 +20,7 @@ class EnumObjectBuilderTest extends CodeFileTestCase
      */
     protected static function getExpectedFilesDir()
     {
-        return parent::getExpectedFilesDir() . '/enum_objects';
+        return parent::getExpectedFilesDir() . DIRECTORY_SEPARATOR . 'enum_objects';
     }
 
     /**
@@ -34,9 +34,11 @@ class EnumObjectBuilderTest extends CodeFileTestCase
         $objectName .= 'EnumObject';
         $enumBuilder->build();
 
-        $this->assertFileEquals(
-            static::getExpectedFilesDir() . "/$objectName.php",
-            static::getGeneratedFilesDir() . "/$objectName.php"
+        $this->assertTrue(
+            $this->assertFileEqualsIgnoreWhitespace(
+                static::getExpectedFilesDir() . DIRECTORY_SEPARATOR . $objectName . ".php",
+                static::getGeneratedFilesDir() . DIRECTORY_SEPARATOR . $objectName . ".php"
+            )
         );
     }
 
@@ -53,9 +55,11 @@ class EnumObjectBuilderTest extends CodeFileTestCase
         $enumBuilder->addEnumValue('fixed_value');
         $enumBuilder->build();
 
-        $this->assertFileEquals(
-            static::getExpectedFilesDir() . "/$objectName.php",
-            static::getGeneratedFilesDir() . "/$objectName.php"
+        $this->assertTrue(
+            $this->assertFileEqualsIgnoreWhitespace(
+                static::getExpectedFilesDir() . DIRECTORY_SEPARATOR . $objectName . ".php",
+                static::getGeneratedFilesDir() . DIRECTORY_SEPARATOR . $objectName . ".php"
+            )
         );
     }
 
@@ -74,9 +78,11 @@ class EnumObjectBuilderTest extends CodeFileTestCase
         $enumBuilder->addEnumValue('oneMoreValue');
         $enumBuilder->build();
 
-        $this->assertFileEquals(
-            static::getExpectedFilesDir() . "/$objectName.php",
-            static::getGeneratedFilesDir() . "/$objectName.php"
+        $this->assertTrue(
+            $this->assertFileEqualsIgnoreWhitespace(
+                static::getExpectedFilesDir() . DIRECTORY_SEPARATOR . $objectName . ".php",
+                static::getGeneratedFilesDir() . DIRECTORY_SEPARATOR . $objectName . ".php"
+            )
         );
     }
 }

--- a/tests/InputObjectClassBuilderTest.php
+++ b/tests/InputObjectClassBuilderTest.php
@@ -16,7 +16,7 @@ class InputObjectClassBuilderTest extends CodeFileTestCase
      */
     protected static function getExpectedFilesDir()
     {
-        return parent::getExpectedFilesDir() . '/input_objects';
+        return parent::getExpectedFilesDir() . DIRECTORY_SEPARATOR . 'input_objects';
     }
 
     /**
@@ -35,9 +35,11 @@ class InputObjectClassBuilderTest extends CodeFileTestCase
         $classBuilder->addScalarValue('valOne');
         $classBuilder->build();
 
-        $this->assertFileEquals(
-            static::getExpectedFilesDir() . "/$objectName.php",
-            static::getGeneratedFilesDir() . "/$objectName.php"
+        $this->assertTrue(
+            $this->assertFileEqualsIgnoreWhitespace(
+                static::getExpectedFilesDir() . DIRECTORY_SEPARATOR . $objectName . ".php",
+                static::getGeneratedFilesDir() . DIRECTORY_SEPARATOR . $objectName . ".php"
+            )
         );
     }
 
@@ -58,9 +60,11 @@ class InputObjectClassBuilderTest extends CodeFileTestCase
         $classBuilder->addScalarValue('val_two');
         $classBuilder->build();
 
-        $this->assertFileEquals(
-            static::getExpectedFilesDir() . "/$objectName.php",
-            static::getGeneratedFilesDir() . "/$objectName.php"
+        $this->assertTrue(
+            $this->assertFileEqualsIgnoreWhitespace(
+                static::getExpectedFilesDir() . DIRECTORY_SEPARATOR . $objectName . ".php",
+                static::getGeneratedFilesDir() . DIRECTORY_SEPARATOR . $objectName . ".php"
+            )
         );
     }
 
@@ -80,9 +84,11 @@ class InputObjectClassBuilderTest extends CodeFileTestCase
         $classBuilder->addListValue('listOne', '');
         $classBuilder->build();
 
-        $this->assertFileEquals(
-            static::getExpectedFilesDir() . "/$objectName.php",
-            static::getGeneratedFilesDir() . "/$objectName.php"
+        $this->assertTrue(
+            $this->assertFileEqualsIgnoreWhitespace(
+                static::getExpectedFilesDir() . DIRECTORY_SEPARATOR . $objectName . ".php",
+                static::getGeneratedFilesDir() . DIRECTORY_SEPARATOR . $objectName . ".php"
+            )
         );
     }
 
@@ -103,9 +109,11 @@ class InputObjectClassBuilderTest extends CodeFileTestCase
         $classBuilder->addListValue('list_two', '');
         $classBuilder->build();
 
-        $this->assertFileEquals(
-            static::getExpectedFilesDir() . "/$objectName.php",
-            static::getGeneratedFilesDir() . "/$objectName.php"
+        $this->assertTrue(
+            $this->assertFileEqualsIgnoreWhitespace(
+                static::getExpectedFilesDir() . DIRECTORY_SEPARATOR . $objectName . ".php",
+                static::getGeneratedFilesDir() . DIRECTORY_SEPARATOR . $objectName . ".php"
+            )
         );
     }
 
@@ -125,9 +133,11 @@ class InputObjectClassBuilderTest extends CodeFileTestCase
         $classBuilder->addInputObjectValue('inputObject', 'WithListValue');
         $classBuilder->build();
 
-        $this->assertFileEquals(
-            static::getExpectedFilesDir() . "/$objectName.php",
-            static::getGeneratedFilesDir() . "/$objectName.php"
+        $this->assertTrue(
+            $this->assertFileEqualsIgnoreWhitespace(
+                static::getExpectedFilesDir() . DIRECTORY_SEPARATOR . $objectName . ".php",
+                static::getGeneratedFilesDir() . DIRECTORY_SEPARATOR . $objectName . ".php"
+            )
         );
     }
 
@@ -148,9 +158,11 @@ class InputObjectClassBuilderTest extends CodeFileTestCase
         $classBuilder->addInputObjectValue('inputObjectTwo', '_TestFilter');
         $classBuilder->build();
 
-        $this->assertFileEquals(
-            static::getExpectedFilesDir() . "/$objectName.php",
-            static::getGeneratedFilesDir() . "/$objectName.php"
+        $this->assertTrue(
+            $this->assertFileEqualsIgnoreWhitespace(
+                static::getExpectedFilesDir() . DIRECTORY_SEPARATOR . $objectName . ".php",
+                static::getGeneratedFilesDir() . DIRECTORY_SEPARATOR . $objectName . ".php"
+            )
         );
     }
 
@@ -169,9 +181,11 @@ class InputObjectClassBuilderTest extends CodeFileTestCase
         $classBuilder->addInputObjectValue('testFilter', '_TestFilter');
         $classBuilder->build();
 
-        $this->assertFileEquals(
-            static::getExpectedFilesDir() . "/$objectName.php",
-            static::getGeneratedFilesDir() . "/$objectName.php"
+        $this->assertTrue(
+            $this->assertFileEqualsIgnoreWhitespace(
+                static::getExpectedFilesDir() . DIRECTORY_SEPARATOR . $objectName . ".php",
+                static::getGeneratedFilesDir() . DIRECTORY_SEPARATOR . $objectName . ".php"
+            )
         );
     }
 }

--- a/tests/QueryObjectClassBuilderTest.php
+++ b/tests/QueryObjectClassBuilderTest.php
@@ -14,7 +14,7 @@ class QueryObjectClassBuilderTest extends CodeFileTestCase
      */
     protected static function getExpectedFilesDir()
     {
-        return parent::getExpectedFilesDir() . '/query_objects';
+        return parent::getExpectedFilesDir() . DIRECTORY_SEPARATOR . 'query_objects';
     }
 
     /**
@@ -28,9 +28,11 @@ class QueryObjectClassBuilderTest extends CodeFileTestCase
         $objectName .= 'QueryObject';
         $classBuilder->build();
 
-        $this->assertFileEquals(
-            static::getExpectedFilesDir() . "/$objectName.php",
-            static::getGeneratedFilesDir() . "/$objectName.php"
+        $this->assertTrue(
+            $this->assertFileEqualsIgnoreWhitespace(
+                static::getExpectedFilesDir() . DIRECTORY_SEPARATOR . $objectName . ".php",
+                static::getGeneratedFilesDir() . DIRECTORY_SEPARATOR . $objectName . ".php"
+            )
         );
     }
 
@@ -45,9 +47,11 @@ class QueryObjectClassBuilderTest extends CodeFileTestCase
         $objectName .= 'QueryObject';
         $classBuilder->build();
 
-        $this->assertFileEquals(
-            static::getExpectedFilesDir() . "/$objectName.php",
-            static::getGeneratedFilesDir() . "/$objectName.php"
+        $this->assertTrue(
+            $this->assertFileEqualsIgnoreWhitespace(
+                static::getExpectedFilesDir() . DIRECTORY_SEPARATOR . $objectName . ".php",
+                static::getGeneratedFilesDir() . DIRECTORY_SEPARATOR . $objectName . ".php"
+            )
         );
     }
 
@@ -63,9 +67,11 @@ class QueryObjectClassBuilderTest extends CodeFileTestCase
         $classBuilder->addScalarField('name');
         $classBuilder->build();
 
-        $this->assertFileEquals(
-            static::getExpectedFilesDir() . "/$objectName.php",
-            static::getGeneratedFilesDir() . "/$objectName.php"
+        $this->assertTrue(
+            $this->assertFileEqualsIgnoreWhitespace(
+                static::getExpectedFilesDir() . DIRECTORY_SEPARATOR . $objectName . ".php",
+                static::getGeneratedFilesDir() . DIRECTORY_SEPARATOR . $objectName . ".php"
+            )
         );
     }
 
@@ -84,9 +90,11 @@ class QueryObjectClassBuilderTest extends CodeFileTestCase
         $classBuilder->addScalarField('last_name');
         $classBuilder->build();
 
-        $this->assertFileEquals(
-            static::getExpectedFilesDir() . "/$objectName.php",
-            static::getGeneratedFilesDir() . "/$objectName.php"
+        $this->assertTrue(
+            $this->assertFileEqualsIgnoreWhitespace(
+                static::getExpectedFilesDir() . DIRECTORY_SEPARATOR . $objectName . ".php",
+                static::getGeneratedFilesDir() . DIRECTORY_SEPARATOR . $objectName . ".php"
+            )
         );
     }
 
@@ -102,9 +110,11 @@ class QueryObjectClassBuilderTest extends CodeFileTestCase
         $classBuilder->addObjectField('others', 'Other', 'RootOthers');
         $classBuilder->build();
 
-        $this->assertFileEquals(
-            static::getExpectedFilesDir() . "/$objectName.php",
-            static::getGeneratedFilesDir() . "/$objectName.php"
+        $this->assertTrue(
+            $this->assertFileEqualsIgnoreWhitespace(
+                static::getExpectedFilesDir() . DIRECTORY_SEPARATOR . $objectName . ".php",
+                static::getGeneratedFilesDir() . DIRECTORY_SEPARATOR . $objectName . ".php"
+            )
         );
     }
 
@@ -123,9 +133,11 @@ class QueryObjectClassBuilderTest extends CodeFileTestCase
         $classBuilder->addObjectField('left_objects', 'Left', 'MultipleObjectSelectorsLeftObjects');
         $classBuilder->build();
 
-        $this->assertFileEquals(
-            static::getExpectedFilesDir() . "/$objectName.php",
-            static::getGeneratedFilesDir() . "/$objectName.php"
+        $this->assertTrue(
+            $this->assertFileEqualsIgnoreWhitespace(
+                static::getExpectedFilesDir() . DIRECTORY_SEPARATOR . $objectName . ".php",
+                static::getGeneratedFilesDir() . DIRECTORY_SEPARATOR . $objectName . ".php"
+            )
         );
     }
 }

--- a/tests/QueryObjectTest.php
+++ b/tests/QueryObjectTest.php
@@ -28,6 +28,11 @@ class QueryObjectTest extends TestCase
         $this->queryObject = new SimpleQueryObject('simples');
     }
 
+    private function replaceWhitespace(string $string) {
+
+        return str_replace(["\t","\n","\r","\0","\x0B"],'', $string );
+    }
+
     /**
      * @covers \GraphQL\SchemaObject\QueryObject::__construct
      * @covers \GraphQL\SchemaObject\QueryObject::getQuery
@@ -36,23 +41,25 @@ class QueryObjectTest extends TestCase
     {
         $object = new SimpleQueryObject();
         $object->selectScalar();
-        $this->assertEquals(
+        $this->assertEquals( $this->replaceWhitespace(
+
             'query {
 Simple {
 scalar
 }
-}',
-            (string) $object->getQuery());
+}'),
+            $this->replaceWhitespace($object->getQuery()));
+
 
         $object = new SimpleQueryObject('test');
         $object->selectScalar();
-        $this->assertEquals(
+        $this->assertEquals( $this->replaceWhitespace(
             'query {
 test {
 scalar
 }
-}',
-            (string) $object->getQuery());
+}'),
+            $this->replaceWhitespace($object->getQuery()));
     }
 
     /**
@@ -72,28 +79,28 @@ scalar
     public function testSelectFields()
     {
         $this->queryObject->selectScalar();
-        $this->assertEquals(
+        $this->assertEquals( $this->replaceWhitespace(
             'query {
 simples {
 scalar
 }
-}',
-            (string) $this->queryObject->getQuery()
+}'),
+            $this->replaceWhitespace($this->queryObject->getQuery())
         );
 
         $this->queryObject->selectAnotherScalar();
-        $this->assertEquals(
+        $this->assertEquals( $this->replaceWhitespace(
             'query {
 simples {
 scalar
 anotherScalar
 }
-}',
-            (string) $this->queryObject->getQuery()
+}'),
+            $this->replaceWhitespace($this->queryObject->getQuery())
         );
 
         $this->queryObject->selectSiblings()->selectScalar();
-        $this->assertEquals(
+        $this->assertEquals( $this->replaceWhitespace(
             'query {
 simples {
 scalar
@@ -102,8 +109,8 @@ siblings {
 scalar
 }
 }
-}',
-            (string) $this->queryObject->getQuery()
+}'),
+            $this->replaceWhitespace($this->queryObject->getQuery())
         );
     }
 
@@ -114,15 +121,15 @@ scalar
     public function testSelectSubFieldsWithArguments()
     {
         $this->queryObject->selectSiblings((new SimpleSiblingsArgumentObject())->setFirst(5)->setIds([1,2]))->selectScalar();
-        $this->assertEquals(
+        $this->assertEquals( $this->replaceWhitespace(
             'query {
 simples {
 siblings(first: 5 ids: [1, 2]) {
 scalar
 }
 }
-}',
-            (string) $this->queryObject->getQuery()
+}'),
+            $this->replaceWhitespace($this->queryObject->getQuery())
         );
 
         $this->setUp();
@@ -141,15 +148,15 @@ scalar
                     )
             )
             ->selectScalar();
-        $this->assertEquals(
+        $this->assertEquals( $this->replaceWhitespace(
             'query {
 simples {
 siblings(obj: {field: "something"}) {
 scalar
 }
 }
-}',
-            (string) $this->queryObject->getQuery()
+}'),
+            $this->replaceWhitespace($this->queryObject->getQuery())
         );
     }
 }

--- a/tests/SchemaClassGeneratorTest.php
+++ b/tests/SchemaClassGeneratorTest.php
@@ -44,13 +44,13 @@ class SchemaClassGeneratorTest extends CodeFileTestCase
         $this->classGenerator = new SchemaClassGenerator(
             new Client('')
         );
-        $this->assertStringEndsWith('/php-graphql-oqm/schema_object', $this->classGenerator->getWriteDir());
+        $this->assertStringEndsWith( DIRECTORY_SEPARATOR . 'php-graphql-oqm' . DIRECTORY_SEPARATOR . 'schema_object', $this->classGenerator->getWriteDir());
 
         $this->classGenerator = new SchemaClassGenerator(
             new Client(''),
             static::getGeneratedFilesDir()
         );
-        $this->assertStringEndsWith('/tests/files_generated', $this->classGenerator->getWriteDir());
+        $this->assertStringEndsWith(DIRECTORY_SEPARATOR . 'tests' . DIRECTORY_SEPARATOR . 'files_generated', $this->classGenerator->getWriteDir());
     }
 
     /**
@@ -167,9 +167,12 @@ class SchemaClassGeneratorTest extends CodeFileTestCase
         $this->classGenerator->generateEnumObject($objectName);
 
         $objectName .= 'EnumObject';
-        $this->assertFileEquals(
-            static::getExpectedFilesDir() . "/enum_objects/$objectName.php",
-            static::getGeneratedFilesDir() . "/$objectName.php"
+
+        $this->assertTrue(
+            $this->assertFileEqualsIgnoreWhitespace(
+                static::getExpectedFilesDir() . DIRECTORY_SEPARATOR . "enum_objects". DIRECTORY_SEPARATOR . $objectName . ".php",
+                static::getGeneratedFilesDir() . DIRECTORY_SEPARATOR . $objectName . ".php"
+            )
         );
     }
 
@@ -215,9 +218,12 @@ class SchemaClassGeneratorTest extends CodeFileTestCase
         $this->classGenerator->generateInputObject($objectName);
 
         $objectName .= 'InputObject';
-        $this->assertFileEquals(
-            static::getExpectedFilesDir() . "/input_objects/$objectName.php",
-            static::getGeneratedFilesDir() . "/$objectName.php"
+
+        $this->assertTrue(
+            $this->assertFileEqualsIgnoreWhitespace(
+                static::getExpectedFilesDir() . DIRECTORY_SEPARATOR . "input_objects" . DIRECTORY_SEPARATOR . $objectName . ".php",
+                static::getGeneratedFilesDir() . DIRECTORY_SEPARATOR . $objectName . ".php"
+            )
         );
     }
 
@@ -278,9 +284,12 @@ class SchemaClassGeneratorTest extends CodeFileTestCase
         $this->classGenerator->generateInputObject($objectName);
 
         $objectName .= 'InputObject';
-        $this->assertFileEquals(
-            static::getExpectedFilesDir() . "/input_objects/$objectName.php",
-            static::getGeneratedFilesDir() . "/$objectName.php"
+
+        $this->assertTrue(
+            $this->assertFileEqualsIgnoreWhitespace(
+                static::getExpectedFilesDir() . DIRECTORY_SEPARATOR . "input_objects" . DIRECTORY_SEPARATOR . $objectName . ".php",
+                static::getGeneratedFilesDir() . DIRECTORY_SEPARATOR . $objectName . ".php"
+            )
         );
     }
 
@@ -344,9 +353,12 @@ class SchemaClassGeneratorTest extends CodeFileTestCase
         $this->classGenerator->generateInputObject($objectName);
 
         $objectName .= 'InputObject';
-        $this->assertFileEquals(
-            static::getExpectedFilesDir() . "/input_objects/$objectName.php",
-            static::getGeneratedFilesDir() . "/$objectName.php"
+
+        $this->assertTrue(
+            $this->assertFileEqualsIgnoreWhitespace(
+                static::getExpectedFilesDir() . DIRECTORY_SEPARATOR . "input_objects" . DIRECTORY_SEPARATOR . $objectName . ".php",
+                static::getGeneratedFilesDir() . DIRECTORY_SEPARATOR . $objectName . ".php"
+            )
         );
     }
 
@@ -383,9 +395,12 @@ class SchemaClassGeneratorTest extends CodeFileTestCase
         $this->classGenerator->generateArgumentsObject('WithMultipleScalarArgs', $argsArray);
 
         $objectName .= 'ArgumentsObject';
-        $this->assertFileEquals(
-            static::getExpectedFilesDir() . "/arguments_objects/$objectName.php",
-            static::getGeneratedFilesDir() . "/$objectName.php"
+
+        $this->assertTrue(
+            $this->assertFileEqualsIgnoreWhitespace(
+                static::getExpectedFilesDir() . DIRECTORY_SEPARATOR . "arguments_objects" . DIRECTORY_SEPARATOR . $objectName . ".php",
+                static::getGeneratedFilesDir() . DIRECTORY_SEPARATOR . $objectName . ".php"
+            )
         );
     }
 
@@ -452,9 +467,12 @@ class SchemaClassGeneratorTest extends CodeFileTestCase
         $this->classGenerator->generateArgumentsObject($objectName, $argsArray);
 
         $objectName .= 'ArgumentsObject';
-        $this->assertFileEquals(
-            static::getExpectedFilesDir() . "/arguments_objects/$objectName.php",
-            static::getGeneratedFilesDir() . "/$objectName.php"
+
+        $this->assertTrue(
+            $this->assertFileEqualsIgnoreWhitespace(
+                static::getExpectedFilesDir() . DIRECTORY_SEPARATOR . "arguments_objects" . DIRECTORY_SEPARATOR . $objectName . ".php",
+                static::getGeneratedFilesDir() . DIRECTORY_SEPARATOR . $objectName . ".php"
+            )
         );
     }
 
@@ -511,9 +529,12 @@ class SchemaClassGeneratorTest extends CodeFileTestCase
         $this->classGenerator->generateArgumentsObject($objectName, $argsArray);
 
         $objectName .= 'ArgumentsObject';
-        $this->assertFileEquals(
-            static::getExpectedFilesDir() . "/arguments_objects/$objectName.php",
-            static::getGeneratedFilesDir() . "/$objectName.php"
+
+        $this->assertTrue(
+            $this->assertFileEqualsIgnoreWhitespace(
+                static::getExpectedFilesDir() . DIRECTORY_SEPARATOR . "arguments_objects" . DIRECTORY_SEPARATOR . $objectName . ".php",
+                static::getGeneratedFilesDir() . DIRECTORY_SEPARATOR . $objectName . ".php"
+            )
         );
     }
 
@@ -560,9 +581,12 @@ class SchemaClassGeneratorTest extends CodeFileTestCase
         $this->classGenerator->generateQueryObject($objectName);
 
         $objectName .= 'QueryObject';
-        $this->assertFileEquals(
-            static::getExpectedFilesDir() . "/query_objects/$objectName.php",
-            static::getGeneratedFilesDir() . "/$objectName.php"
+
+        $this->assertTrue(
+            $this->assertFileEqualsIgnoreWhitespace(
+                static::getExpectedFilesDir() . DIRECTORY_SEPARATOR . "query_objects" . DIRECTORY_SEPARATOR . $objectName . ".php",
+                static::getGeneratedFilesDir() . DIRECTORY_SEPARATOR . $objectName . ".php"
+            )
         );
     }
 
@@ -637,9 +661,12 @@ class SchemaClassGeneratorTest extends CodeFileTestCase
         $objectName .= 'QueryObject';
 
         $this->classGenerator->generateQueryObject($objectName);
-        $this->assertFileEquals(
-            static::getExpectedFilesDir() . "/query_objects/$objectName.php",
-            static::getGeneratedFilesDir() . "/$objectName.php"
+
+        $this->assertTrue(
+            $this->assertFileEqualsIgnoreWhitespace(
+                static::getExpectedFilesDir() . DIRECTORY_SEPARATOR . "query_objects" . DIRECTORY_SEPARATOR . $objectName . ".php",
+                static::getGeneratedFilesDir() . DIRECTORY_SEPARATOR . $objectName . ".php"
+            )
         );
     }
 
@@ -663,9 +690,12 @@ class SchemaClassGeneratorTest extends CodeFileTestCase
         $this->classGenerator->generateRootQueryObject();
 
         $objectName = 'RootQueryObject';
-        $this->assertFileEquals(
-            static::getExpectedFilesDir() . "/query_objects/$objectName.php",
-            static::getGeneratedFilesDir() . "/$objectName.php"
+
+        $this->assertTrue(
+            $this->assertFileEqualsIgnoreWhitespace(
+                static::getExpectedFilesDir() . DIRECTORY_SEPARATOR . "query_objects" . DIRECTORY_SEPARATOR . $objectName . ".php",
+                static::getGeneratedFilesDir() . DIRECTORY_SEPARATOR . $objectName . ".php"
+            )
         );
     }
 

--- a/tests/TraitFileTest.php
+++ b/tests/TraitFileTest.php
@@ -12,7 +12,7 @@ class TraitFileTest extends CodeFileTestCase
      */
     protected static function getExpectedFilesDir()
     {
-        return parent::getExpectedFilesDir() . '/traits';
+        return parent::getExpectedFilesDir() . DIRECTORY_SEPARATOR . 'traits';
     }
 
     /**
@@ -28,7 +28,11 @@ class TraitFileTest extends CodeFileTestCase
         $trait = new TraitFile(static::getGeneratedFilesDir(), $fileName);
         $trait->writeFile();
 
-        $this->assertFileEquals(static::getExpectedFilesDir() . "/$fileName.php", $trait->getWritePath());
+        $this->assertTrue(
+            $this->assertFileEqualsIgnoreWhitespace(
+                static::getExpectedFilesDir() . DIRECTORY_SEPARATOR . $fileName . ".php" , $trait->getWritePath()
+            )
+        );
     }
 
     /**
@@ -46,7 +50,11 @@ class TraitFileTest extends CodeFileTestCase
         $trait->setNamespace("GraphQL\Test");
         $trait->writeFile();
 
-        $this->assertFileEquals(static::getExpectedFilesDir() . "/$fileName.php", $trait->getWritePath());
+        $this->assertTrue(
+            $this->assertFileEqualsIgnoreWhitespace(
+                static::getExpectedFilesDir() . DIRECTORY_SEPARATOR . $fileName . ".php" , $trait->getWritePath()
+            )
+        );
     }
 
     /**
@@ -64,7 +72,11 @@ class TraitFileTest extends CodeFileTestCase
         $trait->setNamespace('');
         $trait->writeFile();
 
-        $this->assertFileEquals(static::getExpectedFilesDir() . "/$fileName.php", $trait->getWritePath());
+        $this->assertTrue(
+            $this->assertFileEqualsIgnoreWhitespace(
+                static::getExpectedFilesDir() . DIRECTORY_SEPARATOR . $fileName . ".php" , $trait->getWritePath()
+            )
+        );
     }
 
     /**
@@ -83,7 +95,11 @@ class TraitFileTest extends CodeFileTestCase
         $trait->addImport("GraphQL\Client");
         $trait->writeFile();
 
-        $this->assertFileEquals(static::getExpectedFilesDir() . "/$fileName.php", $trait->getWritePath());
+        $this->assertTrue(
+            $this->assertFileEqualsIgnoreWhitespace(
+                static::getExpectedFilesDir() . DIRECTORY_SEPARATOR . $fileName . ".php" , $trait->getWritePath()
+            )
+        );
     }
 
     /**
@@ -101,7 +117,11 @@ class TraitFileTest extends CodeFileTestCase
         $trait->addImport("");
         $trait->writeFile();
 
-        $this->assertFileEquals(static::getExpectedFilesDir() . "/$fileName.php", $trait->getWritePath());
+        $this->assertTrue(
+            $this->assertFileEqualsIgnoreWhitespace(
+                static::getExpectedFilesDir() . DIRECTORY_SEPARATOR . $fileName . ".php" , $trait->getWritePath()
+            )
+        );
     }
 
     /**
@@ -123,7 +143,11 @@ class TraitFileTest extends CodeFileTestCase
         $trait->addImport("GraphQL\\Client");
         $trait->writeFile();
 
-        $this->assertFileEquals(static::getExpectedFilesDir() . "/$fileName.php", $trait->getWritePath());
+        $this->assertTrue(
+            $this->assertFileEqualsIgnoreWhitespace(
+                static::getExpectedFilesDir() . DIRECTORY_SEPARATOR . $fileName . ".php" , $trait->getWritePath()
+            )
+        );
     }
 
     /**
@@ -143,7 +167,11 @@ class TraitFileTest extends CodeFileTestCase
         $trait->addProperty('property_three');
         $trait->writeFile();
 
-        $this->assertFileEquals(static::getExpectedFilesDir() . "/$fileName.php" , $trait->getWritePath());
+        $this->assertTrue(
+            $this->assertFileEqualsIgnoreWhitespace(
+                static::getExpectedFilesDir() . DIRECTORY_SEPARATOR . $fileName . ".php" , $trait->getWritePath()
+            )
+        );
 
         return $trait;
     }
@@ -163,7 +191,11 @@ class TraitFileTest extends CodeFileTestCase
         $trait->addProperty('');
         $trait->writeFile();
 
-        $this->assertFileEquals(static::getExpectedFilesDir() . "/$fileName.php" , $trait->getWritePath());
+        $this->assertTrue(
+            $this->assertFileEqualsIgnoreWhitespace(
+                static::getExpectedFilesDir() . DIRECTORY_SEPARATOR . $fileName . ".php" , $trait->getWritePath()
+            )
+        );
     }
 
     /**
@@ -176,11 +208,15 @@ class TraitFileTest extends CodeFileTestCase
      */
     public function testTraitWithDuplicateProperties(TraitFile $trait)
     {
+        $fileName = $trait->getFileName();
         // Adding the same property again
         $trait->addProperty('property1');
 
-        $fileName = $trait->getFileName();
-        $this->assertFileEquals(static::getExpectedFilesDir() . "/$fileName.php" , $trait->getWritePath());
+        $this->assertTrue(
+            $this->assertFileEqualsIgnoreWhitespace(
+                static::getExpectedFilesDir() . DIRECTORY_SEPARATOR . $fileName . ".php" , $trait->getWritePath()
+            )
+        );
     }
 
     /**
@@ -205,7 +241,11 @@ class TraitFileTest extends CodeFileTestCase
         $trait->addProperty('propertySeven', 7.7);
         $trait->writeFile();
 
-        $this->assertFileEquals(static::getExpectedFilesDir() . "/$fileName.php" , $trait->getWritePath());
+        $this->assertTrue(
+            $this->assertFileEqualsIgnoreWhitespace(
+                static::getExpectedFilesDir() . DIRECTORY_SEPARATOR . $fileName . ".php" , $trait->getWritePath()
+            )
+        );
     }
 
     /**
@@ -227,7 +267,11 @@ class TraitFileTest extends CodeFileTestCase
         );
         $trait->writeFile();
 
-        $this->assertFileEquals(static::getExpectedFilesDir() . "/$fileName.php" , $trait->getWritePath());
+        $this->assertTrue(
+            $this->assertFileEqualsIgnoreWhitespace(
+                static::getExpectedFilesDir() . DIRECTORY_SEPARATOR . $fileName . ".php" , $trait->getWritePath()
+            )
+        );
     }
 
     /**
@@ -254,7 +298,11 @@ class TraitFileTest extends CodeFileTestCase
         );
         $trait->writeFile();
 
-        $this->assertFileEquals(static::getExpectedFilesDir() . "/$fileName.php" , $trait->getWritePath());
+        $this->assertTrue(
+            $this->assertFileEqualsIgnoreWhitespace(
+                static::getExpectedFilesDir() . DIRECTORY_SEPARATOR . $fileName . ".php" , $trait->getWritePath()
+            )
+        );
     }
 
     /**
@@ -272,7 +320,11 @@ class TraitFileTest extends CodeFileTestCase
         $trait->addMethod('');
         $trait->writeFile();
 
-        $this->assertFileEquals(static::getExpectedFilesDir() . "/$fileName.php" , $trait->getWritePath());
+        $this->assertTrue(
+            $this->assertFileEqualsIgnoreWhitespace(
+                static::getExpectedFilesDir() . DIRECTORY_SEPARATOR . $fileName . ".php" , $trait->getWritePath()
+            )
+        );
     }
 
     /**
@@ -300,7 +352,11 @@ class TraitFileTest extends CodeFileTestCase
         );
         $trait->writeFile();
 
-        $this->assertFileEquals(static::getExpectedFilesDir() . "/$fileName.php" , $trait->getWritePath());
+        $this->assertTrue(
+            $this->assertFileEqualsIgnoreWhitespace(
+                static::getExpectedFilesDir() . DIRECTORY_SEPARATOR . $fileName . ".php" , $trait->getWritePath()
+            )
+        );
     }
 
     /**
@@ -331,6 +387,11 @@ class TraitFileTest extends CodeFileTestCase
         );
         $trait->writeFile();
 
-        $this->assertFileEquals(static::getExpectedFilesDir() . "/$fileName.php", $trait->getWritePath());
+        $this->assertTrue(
+            $this->assertFileEqualsIgnoreWhitespace(
+                static::getExpectedFilesDir() . DIRECTORY_SEPARATOR . $fileName . ".php", $trait->getWritePath()
+            )
+        );
+
     }
 }


### PR DESCRIPTION
The problem is coming from **php-graphql-client** `FieldTrait.php constructSelectionSet()` where we use a `\n` character to build the query.

I fixed it and other Windows specified problems in the tests for php-graphql-oqm.

1) The problem is with the PHP_EOL constant depending on a platform 

A new line on Windows is `\r\n` , linux `\n` 


2)  testUnwritableDirInConstructor(), testUnwritableDir()   - we need to skip these tests, because windows don't have chmod().

3) DIRECTORY_SEPARATOR  -  depending on a platform` / `or `\`

**The test results on win7 x64 PHP 7.3.9 MINGW64**

```
git clone https://github.com/mghoneimy/php-graphql-oqm/

composer install 
```

<details>
  <summary>vendor/phpunit/phpunit/phpunit tests/ --whitelist src/ --coverage-clover build/coverage/xml</summary>


```

PHPUnit 8.3.4 by Sebastian Bergmann and contributors.

Error:         No code coverage driver is available

PHP Warning:  mkdir(): File exists in X:\php-graphql-oqm\tests\CodeFileTestCase.php on line 31

Warning: mkdir(): File exists in X:\php-graphql-oqm\tests\CodeFileTestCase.php on line 31
.E.E.FSPHP Warning:  rmdir(X:\php-graphql-oqm\tests/files_generated/unwritable): Permission denied in X:\php-graphql-oqm\tests\CodeFileTestCase.php on line 58

Warning: rmdir(X:\php-graphql-oqm\tests/files_generated/unwritable): Permission denied in X:\php-graphql-oqm\tests\CodeFileTestCase.php on line 58
PHP Warning:  rmdir(X:\php-graphql-oqm\tests/files_generated/unwritable-constructor): Permission denied in X:\php-graphql-oqm\tests\CodeFileTestCase.php on line 58

Warning: rmdir(X:\php-graphql-oqm\tests/files_generated/unwritable-constructor): Permission denied in X:\php-graphql-oqm\tests\CodeFileTestCase.php on line 58
PHP Warning:  rmdir(X:\php-graphql-oqm\tests/files_generated): Directory not empty in X:\php-graphql-oqm\tests\CodeFileTestCase.php on line 58

Warning: rmdir(X:\php-graphql-oqm\tests/files_generated): Directory not empty in X:\php-graphql-oqm\tests\CodeFileTestCase.php on line 58
PHP Warning:  mkdir(): File exists in X:\php-graphql-oqm\tests\CodeFileTestCase.php on line 31

Warning: mkdir(): File exists in X:\php-graphql-oqm\tests\CodeFileTestCase.php on line 31
FFFFFFPHP Warning:  rmdir(X:\php-graphql-oqm\tests/files_generated/unwritable): Permission denied in X:\php-graphql-oqm\tests\CodeFileTestCase.php on line 58

Warning: rmdir(X:\php-graphql-oqm\tests/files_generated/unwritable): Permission denied in X:\php-graphql-oqm\tests\CodeFileTestCase.php on line 58
PHP Warning:  rmdir(X:\php-graphql-oqm\tests/files_generated/unwritable-constructor): Permission denied in X:\php-graphql-oqm\tests\CodeFileTestCase.php on line 58

Warning: rmdir(X:\php-graphql-oqm\tests/files_generated/unwritable-constructor): Permission denied in X:\php-graphql-oqm\tests\CodeFileTestCase.php on line 58
PHP Warning:  rmdir(X:\php-graphql-oqm\tests/files_generated): Directory not empty in X:\php-graphql-oqm\tests\CodeFileTestCase.php on line 58

Warning: rmdir(X:\php-graphql-oqm\tests/files_generated): Directory not empty in X:\php-graphql-oqm\tests\CodeFileTestCase.php on line 58
..PHP Warning:  mkdir(): File exists in X:\php-graphql-oqm\tests\CodeFileTestCase.php on line 31

Warning: mkdir(): File exists in X:\php-graphql-oqm\tests\CodeFileTestCase.php on line 31
......FS.FS.SPHP Warning:  rmdir(X:\php-graphql-oqm\tests/files_generated/unwritable): Permission denied in X:\php-graphql-oqm\tests\CodeFileTestCase.php on line 58

Warning: rmdir(X:\php-graphql-oqm\tests/files_generated/unwritable): Permission denied in X:\php-graphql-oqm\tests\CodeFileTestCase.php on line 58
PHP Warning:  rmdir(X:\php-graphql-oqm\tests/files_generated/unwritable-constructor): Permission denied in X:\php-graphql-oqm\tests\CodeFileTestCase.php on line 58

Warning: rmdir(X:\php-graphql-oqm\tests/files_generated/unwritable-constructor): Permission denied in X:\php-graphql-oqm\tests\CodeFileTestCase.php on line 58
PHP Warning:  rmdir(X:\php-graphql-oqm\tests/files_generated): Directory not empty in X:\php-graphql-oqm\tests\CodeFileTestCase.php on line 58

Warning: rmdir(X:\php-graphql-oqm\tests/files_generated): Directory not empty in X:\php-graphql-oqm\tests\CodeFileTestCase.php on line 58
F.......PHP Warning:  mkdir(): File exists in X:\php-graphql-oqm\tests\CodeFileTestCase.php on line 31

Warning: mkdir(): File exists in X:\php-graphql-oqm\tests\CodeFileTestCase.php on line 31
FSSPHP Warning:  rmdir(X:\php-graphql-oqm\tests/files_generated/unwritable): Permission denied in X:\php-graphql-oqm\tests\CodeFileTestCase.php on line 58

Warning: rmdir(X:\php-graphql-oqm\tests/files_generated/unwritable): Permission denied in X:\php-graphql-oqm\tests\CodeFileTestCase.php on line 58
PHP Warning:  rmdir(X:\php-graphql-oqm\tests/files_generated/unwritable-constructor): Permission denied in X:\php-graphql-oqm\tests\CodeFileTestCase.php on line 58

Warning: rmdir(X:\php-graphql-oqm\tests/files_generated/unwritable-constructor): Permission denied in X:\php-graphql-oqm\tests\CodeFileTestCase.php on line 58
PHP Warning:  rmdir(X:\php-graphql-oqm\tests/files_generated): Directory not empty in X:\php-graphql-oqm\tests\CodeFileTestCase.php on line 58

Warning: rmdir(X:\php-graphql-oqm\tests/files_generated): Directory not empty in X:\php-graphql-oqm\tests\CodeFileTestCase.php on line 58
PHP Warning:  mkdir(): File exists in X:\php-graphql-oqm\tests\CodeFileTestCase.php on line 31

Warning: mkdir(): File exists in X:\php-graphql-oqm\tests\CodeFileTestCase.php on line 31
FFFFFFFPHP Warning:  rmdir(X:\php-graphql-oqm\tests/files_generated/unwritable): Permission denied in X:\php-graphql-oqm\tests\CodeFileTestCase.php on line 58

Warning: rmdir(X:\php-graphql-oqm\tests/files_generated/unwritable): Permission denied in X:\php-graphql-oqm\tests\CodeFileTestCase.php on line 58
PHP Warning:  rmdir(X:\php-graphql-oqm\tests/files_generated/unwritable-constructor): Permission denied in X:\php-graphql-oqm\tests\CodeFileTestCase.php on line 58

Warning: rmdir(X:\php-graphql-oqm\tests/files_generated/unwritable-constructor): Permission denied in X:\php-graphql-oqm\tests\CodeFileTestCase.php on line 58
PHP Warning:  rmdir(X:\php-graphql-oqm\tests/files_generated): Directory not empty in X:\php-graphql-oqm\tests\CodeFileTestCase.php on line 58

Warning: rmdir(X:\php-graphql-oqm\tests/files_generated): Directory not empty in X:\php-graphql-oqm\tests\CodeFileTestCase.php on line 58
...PHP Warning:  mkdir(): File exists in X:\php-graphql-oqm\tests\CodeFileTestCase.php on line 31

Warning: mkdir(): File exists in X:\php-graphql-oqm\tests\CodeFileTestCase.php on line 31
FFFSFSPHP Warning:  rmdir(X:\php-graphql-oqm\tests/files_generated/unwritable): Permission denied in X:\php-graphql-oqm\tests\CodeFileTestCase.php on line 58

Warning: rmdir(X:\php-graphql-oqm\tests/files_generated/unwritable): Permission denied in X:\php-graphql-oqm\tests\CodeFileTestCase.php on line 58
PHP Warning:  rmdir(X:\php-graphql-oqm\tests/files_generated/unwritable-constructor): Permission denied in X:\php-graphql-oqm\tests\CodeFileTestCase.php on line 58

Warning: rmdir(X:\php-graphql-oqm\tests/files_generated/unwritable-constructor): Permission denied in X:\php-graphql-oqm\tests\CodeFileTestCase.php on line 58
PHP Warning:  rmdir(X:\php-graphql-oqm\tests/files_generated): Directory not empty in X:\php-graphql-oqm\tests\CodeFileTestCase.php on line 58

Warning: rmdir(X:\php-graphql-oqm\tests/files_generated): Directory not empty in X:\php-graphql-oqm\tests\CodeFileTestCase.php on line 58
F.FFPHP Warning:  mkdir(): File exists in X:\php-graphql-oqm\tests\CodeFileTestCase.php on line 31

Warning: mkdir(): File exists in X:\php-graphql-oqm\tests\CodeFileTestCase.php on line 31
F...FF 65 / 89 ( 73%)
FFFFFFFF.PHP Warning:  rmdir(X:\php-graphql-oqm\tests/files_generated/unwritable): Permission denied in X:\php-graphql-oqm\tests\CodeFileTestCase.php on line 58

Warning: rmdir(X:\php-graphql-oqm\tests/files_generated/unwritable): Permission denied in X:\php-graphql-oqm\tests\CodeFileTestCase.php on line 58
PHP Warning:  rmdir(X:\php-graphql-oqm\tests/files_generated/unwritable-constructor): Permission denied in X:\php-graphql-oqm\tests\CodeFileTestCase.php on line 58

Warning: rmdir(X:\php-graphql-oqm\tests/files_generated/unwritable-constructor): Permission denied in X:\php-graphql-oqm\tests\CodeFileTestCase.php on line 58
PHP Warning:  rmdir(X:\php-graphql-oqm\tests/files_generated): Directory not empty in X:\php-graphql-oqm\tests\CodeFileTestCase.php on line 58

Warning: rmdir(X:\php-graphql-oqm\tests/files_generated): Directory not empty in X:\php-graphql-oqm\tests\CodeFileTestCase.php on line 58
PHP Warning:  mkdir(): File exists in X:\php-graphql-oqm\tests\CodeFileTestCase.php on line 31

Warning: mkdir(): File exists in X:\php-graphql-oqm\tests\CodeFileTestCase.php on line 31
.F.F.SFSSS...SS                                          89 / 89 (100%)PHP Warning:  rmdir(X:\php-graphql-oqm\tests/files_generated/unwritable): Permission denied in X:\php-graphql-oqm\tests\CodeFileTestCase.php on line 58

Warning: rmdir(X:\php-graphql-oqm\tests/files_generated/unwritable): Permission denied in X:\php-graphql-oqm\tests\CodeFileTestCase.php on line 58
PHP Warning:  rmdir(X:\php-graphql-oqm\tests/files_generated/unwritable-constructor): Permission denied in X:\php-graphql-oqm\tests\CodeFileTestCase.php on line 58

Warning: rmdir(X:\php-graphql-oqm\tests/files_generated/unwritable-constructor): Permission denied in X:\php-graphql-oqm\tests\CodeFileTestCase.php on line 58
PHP Warning:  rmdir(X:\php-graphql-oqm\tests/files_generated): Directory not empty in X:\php-graphql-oqm\tests\CodeFileTestCase.php on line 58

Warning: rmdir(X:\php-graphql-oqm\tests/files_generated): Directory not empty in X:\php-graphql-oqm\tests\CodeFileTestCase.php on line 58


Time: 380 ms, Memory: 8.00 MB

There were 2 errors:

1) GraphQL\Tests\AbstractCodeFileTest::testUnwritableDirInConstructor
mkdir(): File exists

X:\php-graphql-oqm\tests\AbstractCodeFileTest.php:70

2) GraphQL\Tests\AbstractCodeFileTest::testUnwritableDir
mkdir(): File exists

X:\php-graphql-oqm\tests\AbstractCodeFileTest.php:102

--

There were 39 failures:

1) GraphQL\Tests\AbstractCodeFileTest::testFileWritingWorks
Failed asserting that two strings are equal.
--- Expected
+++ Actual
@@ @@
-'<?php\r\n
+'<?php\n
 '

X:\php-graphql-oqm\tests\AbstractCodeFileTest.php:127

2) GraphQL\Tests\ArgumentsObjectClassBuilderTest::testAddScalarArgument
Failed asserting that two strings are equal.
--- Expected
+++ Actual
@@ @@
 '<?php\r\n
 \r\n
-namespace GraphQL\Tests\SchemaObject;\r\n
+namespace GraphQL\Tests\SchemaObject;\n
 \r\n
-use GraphQL\SchemaObject\ArgumentsObject;\r\n
+use GraphQL\SchemaObject\ArgumentsObject;\n
 \r\n
 class WithScalarArgArgumentsObject extends ArgumentsObject\r\n
 {\r\n
-    protected $scalarProperty;\r\n
+    protected $scalarProperty;\n
 \r\n
     public function setScalarProperty($scalarProperty)\r\n
     {\r\n

X:\php-graphql-oqm\tests\ArgumentsObjectClassBuilderTest.php:43

3) GraphQL\Tests\ArgumentsObjectClassBuilderTest::testAddMultipleScalarArguments
Failed asserting that two strings are equal.
--- Expected
+++ Actual
@@ @@
 '<?php\r\n
 \r\n
-namespace GraphQL\Tests\SchemaObject;\r\n
+namespace GraphQL\Tests\SchemaObject;\n
 \r\n
-use GraphQL\SchemaObject\ArgumentsObject;\r\n
+use GraphQL\SchemaObject\ArgumentsObject;\n
 \r\n
 class WithMultipleScalarArgsArgumentsObject extends ArgumentsObject\r\n
 {\r\n
-    protected $scalarProperty;\r\n
-    protected $another_scalar_property;\r\n
+    protected $scalarProperty;\n
+    protected $another_scalar_property;\n
 \r\n
     public function setScalarProperty($scalarProperty)\r\n
     {\r\n

X:\php-graphql-oqm\tests\ArgumentsObjectClassBuilderTest.php:66

4) GraphQL\Tests\ArgumentsObjectClassBuilderTest::testAddListArgument
Failed asserting that two strings are equal.
--- Expected
+++ Actual
@@ @@
 '<?php\r\n
 \r\n
-namespace GraphQL\Tests\SchemaObject;\r\n
+namespace GraphQL\Tests\SchemaObject;\n
 \r\n
-use GraphQL\SchemaObject\ArgumentsObject;\r\n
+use GraphQL\SchemaObject\ArgumentsObject;\n
 \r\n
 class WithListArgArgumentsObject extends ArgumentsObject\r\n
 {\r\n
-    protected $listProperty;\r\n
+    protected $listProperty;\n
 \r\n
     public function setListProperty(array $listProperty)\r\n
     {\r\n

X:\php-graphql-oqm\tests\ArgumentsObjectClassBuilderTest.php:88

5) GraphQL\Tests\ArgumentsObjectClassBuilderTest::testAddMultipleListArguments
Failed asserting that two strings are equal.
--- Expected
+++ Actual
@@ @@
 '<?php\r\n
 \r\n
-namespace GraphQL\Tests\SchemaObject;\r\n
+namespace GraphQL\Tests\SchemaObject;\n
 \r\n
-use GraphQL\SchemaObject\ArgumentsObject;\r\n
+use GraphQL\SchemaObject\ArgumentsObject;\n
 \r\n
 class WithMultipleListArgsArgumentsObject extends ArgumentsObject\r\n
 {\r\n
-    protected $listProperty;\r\n
-    protected $another_list_property;\r\n
+    protected $listProperty;\n
+    protected $another_list_property;\n
 \r\n
     public function setListProperty(array $listProperty)\r\n
     {\r\n

X:\php-graphql-oqm\tests\ArgumentsObjectClassBuilderTest.php:111

6) GraphQL\Tests\ArgumentsObjectClassBuilderTest::testAddInputObjectArgument
Failed asserting that two strings are equal.
--- Expected
+++ Actual
@@ @@
 '<?php\r\n
 \r\n
-namespace GraphQL\Tests\SchemaObject;\r\n
+namespace GraphQL\Tests\SchemaObject;\n
 \r\n
-use GraphQL\SchemaObject\ArgumentsObject;\r\n
+use GraphQL\SchemaObject\ArgumentsObject;\n
 \r\n
 class WithInputObjectArgArgumentsObject extends ArgumentsObject\r\n
 {\r\n
-    protected $objectProperty;\r\n
+    protected $objectProperty;\n
 \r\n
     public function setObjectProperty(SomeInputObject $someInputObject)\r\n
     {\r\n

X:\php-graphql-oqm\tests\ArgumentsObjectClassBuilderTest.php:133

7) GraphQL\Tests\ArgumentsObjectClassBuilderTest::testAddMultipleInputObjectArguments
Failed asserting that two strings are equal.
--- Expected
+++ Actual
@@ @@
 '<?php\r\n
 \r\n
-namespace GraphQL\Tests\SchemaObject;\r\n
+namespace GraphQL\Tests\SchemaObject;\n
 \r\n
-use GraphQL\SchemaObject\ArgumentsObject;\r\n
+use GraphQL\SchemaObject\ArgumentsObject;\n
 \r\n
 class WithMultipleInputObjectArgsArgumentsObject extends ArgumentsObject\r\n
 {\r\n
-    protected $objectProperty;\r\n
-    protected $another_object_property;\r\n
+    protected $objectProperty;\n
+    protected $another_object_property;\n
 \r\n
     public function setObjectProperty(SomeInputObject $someInputObject)\r\n
     {\r\n

X:\php-graphql-oqm\tests\ArgumentsObjectClassBuilderTest.php:156

8) GraphQL\Tests\ClassFileTest::testUseTraits
Failed asserting that two strings are equal.
--- Expected
+++ Actual
@@ @@
 \r\n
 class ClassWithTrait\r\n
 {\r\n
-    use TraitOne;\r\n
+    use TraitOne;\n
 }'

X:\php-graphql-oqm\tests\ClassFileTest.php:138

9) GraphQL\Tests\ClassFileTest::testClassWithConstants
Failed asserting that two strings are equal.
--- Expected
+++ Actual
@@ @@
 \r\n
 class ClassWithConstant\r\n
 {\r\n
-    const CONST_ONE = "ONE";\r\n
+    const CONST_ONE = "ONE";\n
 }'

X:\php-graphql-oqm\tests\ClassFileTest.php:197

10) GraphQL\Tests\ClientTest::testConstructClient
Failed asserting that two strings are equal.
--- Expected
+++ Actual
@@ @@
-'{"query":"query_string"}'
+'{"query":"query_string","variables":{}}'

X:\php-graphql-oqm\tests\ClientTest.php:66

11) GraphQL\Tests\EnumObjectBuilderTest::testBuildEmptyEnum
Failed asserting that two strings are equal.
--- Expected
+++ Actual
@@ @@
 '<?php\r\n
 \r\n
-namespace GraphQL\Tests\SchemaObject;\r\n
+namespace GraphQL\Tests\SchemaObject;\n
 \r\n
-use GraphQL\SchemaObject\EnumObject;\r\n
+use GraphQL\SchemaObject\EnumObject;\n
 \r\n
 class EmptyEnumObject extends EnumObject\r\n
 {}'

X:\php-graphql-oqm\tests\EnumObjectBuilderTest.php:39

12) GraphQL\Tests\InputObjectClassBuilderTest::testAddScalarValue
Failed asserting that two strings are equal.
--- Expected
+++ Actual
@@ @@
 '<?php\r\n
 \r\n
-namespace GraphQL\Tests\SchemaObject;\r\n
+namespace GraphQL\Tests\SchemaObject;\n
 \r\n
-use GraphQL\SchemaObject\InputObject;\r\n
+use GraphQL\SchemaObject\InputObject;\n
 \r\n
 class WithScalarValueInputObject extends InputObject\r\n
 {\r\n
-    protected $valOne;\r\n
+    protected $valOne;\n
 \r\n
     public function setValOne($valOne)\r\n
     {\r\n

X:\php-graphql-oqm\tests\InputObjectClassBuilderTest.php:40

13) GraphQL\Tests\InputObjectClassBuilderTest::testAddMultipleScalarValues
Failed asserting that two strings are equal.
--- Expected
+++ Actual
@@ @@
 '<?php\r\n
 \r\n
-namespace GraphQL\Tests\SchemaObject;\r\n
+namespace GraphQL\Tests\SchemaObject;\n
 \r\n
-use GraphQL\SchemaObject\InputObject;\r\n
+use GraphQL\SchemaObject\InputObject;\n
 \r\n
 class WithMultipleScalarValuesInputObject extends InputObject\r\n
 {\r\n
-    protected $valOne;\r\n
-    protected $val_two;\r\n
+    protected $valOne;\n
+    protected $val_two;\n
 \r\n
     public function setValOne($valOne)\r\n
     {\r\n

X:\php-graphql-oqm\tests\InputObjectClassBuilderTest.php:63

14) GraphQL\Tests\InputObjectClassBuilderTest::testAddListValue
Failed asserting that two strings are equal.
--- Expected
+++ Actual
@@ @@
 '<?php\r\n
 \r\n
-namespace GraphQL\Tests\SchemaObject;\r\n
+namespace GraphQL\Tests\SchemaObject;\n
 \r\n
-use GraphQL\SchemaObject\InputObject;\r\n
+use GraphQL\SchemaObject\InputObject;\n
 \r\n
 class WithListValueInputObject extends InputObject\r\n
 {\r\n
-    protected $listOne;\r\n
+    protected $listOne;\n
 \r\n
     public function setListOne(array $listOne)\r\n
     {\r\n

X:\php-graphql-oqm\tests\InputObjectClassBuilderTest.php:85

15) GraphQL\Tests\InputObjectClassBuilderTest::testAddMultipleListValues
Failed asserting that two strings are equal.
--- Expected
+++ Actual
@@ @@
 '<?php\r\n
 \r\n
-namespace GraphQL\Tests\SchemaObject;\r\n
+namespace GraphQL\Tests\SchemaObject;\n
 \r\n
-use GraphQL\SchemaObject\InputObject;\r\n
+use GraphQL\SchemaObject\InputObject;\n
 \r\n
 class WithMultipleListValuesInputObject extends InputObject\r\n
 {\r\n
-    protected $listOne;\r\n
-    protected $list_two;\r\n
+    protected $listOne;\n
+    protected $list_two;\n
 \r\n
     public function setListOne(array $listOne)\r\n
     {\r\n

X:\php-graphql-oqm\tests\InputObjectClassBuilderTest.php:108

16) GraphQL\Tests\InputObjectClassBuilderTest::testAddInputObjectValue
Failed asserting that two strings are equal.
--- Expected
+++ Actual
@@ @@
 '<?php\r\n
 \r\n
-namespace GraphQL\Tests\SchemaObject;\r\n
+namespace GraphQL\Tests\SchemaObject;\n
 \r\n
-use GraphQL\SchemaObject\InputObject;\r\n
+use GraphQL\SchemaObject\InputObject;\n
 \r\n
 class WithInputObjectValueInputObject extends InputObject\r\n
 {\r\n
-    protected $inputObject;\r\n
+    protected $inputObject;\n
 \r\n
     public function setInputObject(WithListValueInputObject $withListValueInputObject)\r\n
     {\r\n

X:\php-graphql-oqm\tests\InputObjectClassBuilderTest.php:130

17) GraphQL\Tests\InputObjectClassBuilderTest::testAddMultipleInputObjectValues
Failed asserting that two strings are equal.
--- Expected
+++ Actual
@@ @@
 '<?php\r\n
 \r\n
-namespace GraphQL\Tests\SchemaObject;\r\n
+namespace GraphQL\Tests\SchemaObject;\n
 \r\n
-use GraphQL\SchemaObject\InputObject;\r\n
+use GraphQL\SchemaObject\InputObject;\n
 \r\n
 class WithMultipleInputObjectValuesInputObject extends InputObject\r\n
 {\r\n
-    protected $inputObject;\r\n
-    protected $inputObjectTwo;\r\n
+    protected $inputObject;\n
+    protected $inputObjectTwo;\n
 \r\n
     public function setInputObject(WithListValueInputObject $withListValueInputObject)\r\n
     {\r\n

X:\php-graphql-oqm\tests\InputObjectClassBuilderTest.php:153

18) GraphQL\Tests\InputObjectClassBuilderTest::testInputObjectIntegration
Failed asserting that two strings are equal.
--- Expected
+++ Actual
@@ @@
 '<?php\r\n
 \r\n
-namespace GraphQL\Tests\SchemaObject;\r\n
+namespace GraphQL\Tests\SchemaObject;\n
 \r\n
-use GraphQL\SchemaObject\InputObject;\r\n
+use GraphQL\SchemaObject\InputObject;\n
 \r\n
 class _TestFilterInputObject extends InputObject\r\n
 {\r\n
-    protected $first_name;\r\n
-    protected $lastName;\r\n
-    protected $ids;\r\n
-    protected $testFilter;\r\n
+    protected $first_name;\n
+    protected $lastName;\n
+    protected $ids;\n
+    protected $testFilter;\n
 \r\n
     public function setFirstName($firstName)\r\n
     {\r\n

X:\php-graphql-oqm\tests\InputObjectClassBuilderTest.php:174

19) GraphQL\Tests\QueryObjectClassBuilderTest::testBuildEmptyQueryObject
Failed asserting that two strings are equal.
--- Expected
+++ Actual
@@ @@
 '<?php\r\n
 \r\n
-namespace GraphQL\Tests\SchemaObject;\r\n
+namespace GraphQL\Tests\SchemaObject;\n
 \r\n
-use GraphQL\SchemaObject\QueryObject;\r\n
+use GraphQL\SchemaObject\QueryObject;\n
 \r\n
 class EmptyQueryObject extends QueryObject\r\n
 {\r\n
-    const OBJECT_NAME = "Empty";\r\n
+    const OBJECT_NAME = "Empty";\n
 }'

X:\php-graphql-oqm\tests\QueryObjectClassBuilderTest.php:33

20) GraphQL\Tests\QueryObjectClassBuilderTest::testBuildRootQueryObject
Failed asserting that two strings are equal.
--- Expected
+++ Actual
@@ @@
 '<?php\r\n
 \r\n
-namespace GraphQL\Tests\SchemaObject;\r\n
+namespace GraphQL\Tests\SchemaObject;\n
 \r\n
-use GraphQL\SchemaObject\QueryObject;\r\n
+use GraphQL\SchemaObject\QueryObject;\n
 \r\n
 class RootQueryObject extends QueryObject\r\n
 {\r\n
-    const OBJECT_NAME = "query";\r\n
+    const OBJECT_NAME = "query";\n
 }'

X:\php-graphql-oqm\tests\QueryObjectClassBuilderTest.php:50

21) GraphQL\Tests\QueryObjectClassBuilderTest::testAddSimpleSelector
Failed asserting that two strings are equal.
--- Expected
+++ Actual
@@ @@
 '<?php\r\n
 \r\n
-namespace GraphQL\Tests\SchemaObject;\r\n
+namespace GraphQL\Tests\SchemaObject;\n
 \r\n
-use GraphQL\SchemaObject\QueryObject;\r\n
+use GraphQL\SchemaObject\QueryObject;\n
 \r\n
 class SimpleSelectorQueryObject extends QueryObject\r\n
 {\r\n
-    const OBJECT_NAME = "SimpleSelector";\r\n
+    const OBJECT_NAME = "SimpleSelector";\n
 \r\n
     public function selectName()\r\n
     {\r\n

X:\php-graphql-oqm\tests\QueryObjectClassBuilderTest.php:68

22) GraphQL\Tests\QueryObjectClassBuilderTest::testAddObjectSelector
Failed asserting that two strings are equal.
--- Expected
+++ Actual
@@ @@
 '<?php\r\n
 \r\n
-namespace GraphQL\Tests\SchemaObject;\r\n
+namespace GraphQL\Tests\SchemaObject;\n
 \r\n
-use GraphQL\SchemaObject\QueryObject;\r\n
+use GraphQL\SchemaObject\QueryObject;\n
 \r\n
 class ObjectSelectorQueryObject extends QueryObject\r\n
 {\r\n
-    const OBJECT_NAME = "ObjectSelector";\r\n
+    const OBJECT_NAME = "ObjectSelector";\n
 \r\n
     public function selectOthers(RootOthersArgumentsObject $argsObject = null)\r\n
     {\r\n

X:\php-graphql-oqm\tests\QueryObjectClassBuilderTest.php:107

23) GraphQL\Tests\QueryObjectTest::testConstruct
Failed asserting that two strings are equal.
--- Expected
+++ Actual
@@ @@
-'query {\r\n
-Simple {\r\n
-scalar\r\n
-}\r\n
+'query {\n
+Simple {\n
+scalar\n
+}\n
 }'

X:\php-graphql-oqm\tests\QueryObjectTest.php:45

24) GraphQL\Tests\QueryObjectTest::testSelectFields
Failed asserting that two strings are equal.
--- Expected
+++ Actual
@@ @@
-'query {\r\n
-simples {\r\n
-scalar\r\n
-}\r\n
+'query {\n
+simples {\n
+scalar\n
+}\n
 }'

X:\php-graphql-oqm\tests\QueryObjectTest.php:81

25) GraphQL\Tests\QueryObjectTest::testSelectSubFieldsWithArguments
Failed asserting that two strings are equal.
--- Expected
+++ Actual
@@ @@
-'query {\r\n
-simples {\r\n
-siblings(first: 5 ids: [1, 2]) {\r\n
-scalar\r\n
-}\r\n
-}\r\n
+'query {\n
+simples {\n
+siblings(first: 5 ids: [1, 2]) {\n
+scalar\n
+}\n
+}\n
 }'

X:\php-graphql-oqm\tests\QueryObjectTest.php:125

26) GraphQL\Tests\SchemaClassGeneratorTest::testSetWriteDirectory
Failed asserting that 'X:\php-graphql-oqm/schema_object' ends with "/php-graphql-oqm/schema_object".

X:\php-graphql-oqm\tests\SchemaClassGeneratorTest.php:47

27) GraphQL\Tests\SchemaClassGeneratorTest::testGenerateEnumObject
Failed asserting that two strings are equal.
--- Expected
+++ Actual
@@ @@
 '<?php\r\n
 \r\n
-namespace GraphQL\Tests\SchemaObject;\r\n
+namespace GraphQL\Tests\SchemaObject;\n
 \r\n
-use GraphQL\SchemaObject\EnumObject;\r\n
+use GraphQL\SchemaObject\EnumObject;\n
 \r\n
 class WithMultipleConstantsEnumObject extends EnumObject\r\n
 {\r\n
-    const SOME_VALUE = "some_value";\r\n
-    const ANOTHER_VALUE = "another_value";\r\n
-    const ONEMOREVALUE = "oneMoreValue";\r\n
+    const SOME_VALUE = "some_value";\n
+    const ANOTHER_VALUE = "another_value";\n
+    const ONEMOREVALUE = "oneMoreValue";\n
 }'

X:\php-graphql-oqm\tests\SchemaClassGeneratorTest.php:172

28) GraphQL\Tests\SchemaClassGeneratorTest::testGenerateInputObjectWithScalarValues
Failed asserting that two strings are equal.
--- Expected
+++ Actual
@@ @@
 '<?php\r\n
 \r\n
-namespace GraphQL\Tests\SchemaObject;\r\n
+namespace GraphQL\Tests\SchemaObject;\n
 \r\n
-use GraphQL\SchemaObject\InputObject;\r\n
+use GraphQL\SchemaObject\InputObject;\n
 \r\n
 class WithMultipleScalarValuesInputObject extends InputObject\r\n
 {\r\n
-    protected $valOne;\r\n
-    protected $val_two;\r\n
+    protected $valOne;\n
+    protected $val_two;\n
 \r\n
     public function setValOne($valOne)\r\n
     {\r\n

X:\php-graphql-oqm\tests\SchemaClassGeneratorTest.php:220

29) GraphQL\Tests\SchemaClassGeneratorTest::testGenerateInputObjectWithListValues
Failed asserting that two strings are equal.
--- Expected
+++ Actual
@@ @@
 '<?php\r\n
 \r\n
-namespace GraphQL\Tests\SchemaObject;\r\n
+namespace GraphQL\Tests\SchemaObject;\n
 \r\n
-use GraphQL\SchemaObject\InputObject;\r\n
+use GraphQL\SchemaObject\InputObject;\n
 \r\n
 class WithMultipleListValuesInputObject extends InputObject\r\n
 {\r\n
-    protected $listOne;\r\n
-    protected $list_two;\r\n
+    protected $listOne;\n
+    protected $list_two;\n
 \r\n
     public function setListOne(array $listOne)\r\n
     {\r\n

X:\php-graphql-oqm\tests\SchemaClassGeneratorTest.php:283

30) GraphQL\Tests\SchemaClassGeneratorTest::testGenerateInputObjectWithNestedObjectValues
Failed asserting that two strings are equal.
--- Expected
+++ Actual
@@ @@
 '<?php\r\n
 \r\n
-namespace GraphQL\Tests\SchemaObject;\r\n
+namespace GraphQL\Tests\SchemaObject;\n
 \r\n
-use GraphQL\SchemaObject\InputObject;\r\n
+use GraphQL\SchemaObject\InputObject;\n
 \r\n
 class WithMultipleInputObjectValuesInputObject extends InputObject\r\n
 {\r\n
-    protected $inputObject;\r\n
-    protected $inputObjectTwo;\r\n
+    protected $inputObject;\n
+    protected $inputObjectTwo;\n
 \r\n
     public function setInputObject(WithListValueInputObject $withListValueInputObject)\r\n
     {\r\n

X:\php-graphql-oqm\tests\SchemaClassGeneratorTest.php:349

31) GraphQL\Tests\SchemaClassGeneratorTest::testGenerateArgumentsObjectWithScalarArgs
Failed asserting that two strings are equal.
--- Expected
+++ Actual
@@ @@
 '<?php\r\n
 \r\n
-namespace GraphQL\Tests\SchemaObject;\r\n
+namespace GraphQL\Tests\SchemaObject;\n
 \r\n
-use GraphQL\SchemaObject\ArgumentsObject;\r\n
+use GraphQL\SchemaObject\ArgumentsObject;\n
 \r\n
 class WithMultipleScalarArgsArgumentsObject extends ArgumentsObject\r\n
 {\r\n
-    protected $scalarProperty;\r\n
-    protected $another_scalar_property;\r\n
+    protected $scalarProperty;\n
+    protected $another_scalar_property;\n
 \r\n
     public function setScalarProperty($scalarProperty)\r\n
     {\r\n

X:\php-graphql-oqm\tests\SchemaClassGeneratorTest.php:388

32) GraphQL\Tests\SchemaClassGeneratorTest::testGenerateArgumentsObjectWithListArgs
Failed asserting that two strings are equal.
--- Expected
+++ Actual
@@ @@
 '<?php\r\n
 \r\n
-namespace GraphQL\Tests\SchemaObject;\r\n
+namespace GraphQL\Tests\SchemaObject;\n
 \r\n
-use GraphQL\SchemaObject\ArgumentsObject;\r\n
+use GraphQL\SchemaObject\ArgumentsObject;\n
 \r\n
 class WithMultipleListArgsArgumentsObject extends ArgumentsObject\r\n
 {\r\n
-    protected $listProperty;\r\n
-    protected $another_list_property;\r\n
+    protected $listProperty;\n
+    protected $another_list_property;\n
 \r\n
     public function setListProperty(array $listProperty)\r\n
     {\r\n

X:\php-graphql-oqm\tests\SchemaClassGeneratorTest.php:457

33) GraphQL\Tests\SchemaClassGeneratorTest::testGenerateArgumentsObjectWithInputObjectArgs
Failed asserting that two strings are equal.
--- Expected
+++ Actual
@@ @@
 '<?php\r\n
 \r\n
-namespace GraphQL\Tests\SchemaObject;\r\n
+namespace GraphQL\Tests\SchemaObject;\n
 \r\n
-use GraphQL\SchemaObject\ArgumentsObject;\r\n
+use GraphQL\SchemaObject\ArgumentsObject;\n
 \r\n
 class WithMultipleInputObjectArgsArgumentsObject extends ArgumentsObject\r\n
 {\r\n
-    protected $objectProperty;\r\n
-    protected $another_object_property;\r\n
+    protected $objectProperty;\n
+    protected $another_object_property;\n
 \r\n
     public function setObjectProperty(SomeInputObject $someInputObject)\r\n
     {\r\n

X:\php-graphql-oqm\tests\SchemaClassGeneratorTest.php:516

34) GraphQL\Tests\SchemaClassGeneratorTest::testGenerateQueryObjectWithScalarFields
Failed asserting that two strings are equal.
--- Expected
+++ Actual
@@ @@
 '<?php\r\n
 \r\n
-namespace GraphQL\Tests\SchemaObject;\r\n
+namespace GraphQL\Tests\SchemaObject;\n
 \r\n
-use GraphQL\SchemaObject\QueryObject;\r\n
+use GraphQL\SchemaObject\QueryObject;\n
 \r\n
 class MultipleSimpleSelectorsQueryObject extends QueryObject\r\n
 {\r\n
-    const OBJECT_NAME = "MultipleSimpleSelectors";\r\n
+    const OBJECT_NAME = "MultipleSimpleSelectors";\n
 \r\n
     public function selectFirstName()\r\n
     {\r\n

X:\php-graphql-oqm\tests\SchemaClassGeneratorTest.php:565

35) GraphQL\Tests\SchemaClassGeneratorTest::testGenerateQueryObjectWithObjectFields
Failed asserting that two strings are equal.
--- Expected
+++ Actual
@@ @@
 '<?php\r\n
 \r\n
-namespace GraphQL\Tests\SchemaObject;\r\n
+namespace GraphQL\Tests\SchemaObject;\n
 \r\n
-use GraphQL\SchemaObject\QueryObject;\r\n
+use GraphQL\SchemaObject\QueryObject;\n
 \r\n
 class MultipleObjectSelectorsQueryObject extends QueryObject\r\n
 {\r\n
-    const OBJECT_NAME = "MultipleObjectSelectors";\r\n
+    const OBJECT_NAME = "MultipleObjectSelectors";\n
 \r\n
     public function selectRightObjects(MultipleObjectSelectorsRightObjectsArgumentsObject $argsObject = null)\r\n
     {\r\n

X:\php-graphql-oqm\tests\SchemaClassGeneratorTest.php:642

36) GraphQL\Tests\SchemaClassGeneratorTest::testGenerateRootObject
Failed asserting that two strings are equal.
--- Expected
+++ Actual
@@ @@
 '<?php\r\n
 \r\n
-namespace GraphQL\Tests\SchemaObject;\r\n
+namespace GraphQL\Tests\SchemaObject;\n
 \r\n
-use GraphQL\SchemaObject\QueryObject;\r\n
+use GraphQL\SchemaObject\QueryObject;\n
 \r\n
 class RootQueryObject extends QueryObject\r\n
 {\r\n
-    const OBJECT_NAME = "query";\r\n
+    const OBJECT_NAME = "query";\n
 }'

X:\php-graphql-oqm\tests\SchemaClassGeneratorTest.php:668

37) GraphQL\Tests\TraitFileTest::testTraitWithNamespace
Failed asserting that two strings are equal.
--- Expected
+++ Actual
@@ @@
 '<?php\r\n
 \r\n
-namespace GraphQL\Test;\r\n
+namespace GraphQL\Test;\n
 \r\n
 trait TraitWithNamespace\r\n
 {}'

X:\php-graphql-oqm\tests\TraitFileTest.php:49

38) GraphQL\Tests\TraitFileTest::testTraitWithImports
Failed asserting that two strings are equal.
--- Expected
+++ Actual
@@ @@
 '<?php\r\n
 \r\n
-use GraphQL\Query;\r\n
-use GraphQL\Client;\r\n
+use GraphQL\Query;\n
+use GraphQL\Client;\n
 \r\n
 trait TraitWithImports\r\n
 {}'

X:\php-graphql-oqm\tests\TraitFileTest.php:86

39) GraphQL\Tests\TraitFileTest::testTraitWithProperties
Failed asserting that two strings are equal.
--- Expected
+++ Actual
@@ @@
 \r\n
 trait TraitWithProperties\r\n
 {\r\n
-    protected $property1;\r\n
-    protected $propertyTwo;\r\n
-    protected $property_three;\r\n
+    protected $property1;\n
+    protected $propertyTwo;\n
+    protected $property_three;\n
 }'

X:\php-graphql-oqm\tests\TraitFileTest.php:146

ERRORS!
Tests: 89, Assertions: 181, Errors: 2, Failures: 39, Skipped: 14.

```
</details>


**Tests with this PR on win7 x64 PHP 7.3.9 MINGW64**

```
vendor/phpunit/phpunit/phpunit tests/ --whitelist src/ --coverage-clover build/coverage/xml
PHPUnit 7.5.15 by Sebastian Bergmann and contributors.

Error:         No code coverage driver is available

.S.S............................................................. 65 / 89 ( 73%)
........................                                          89 / 89 (100%)

Time: 709 ms, Memory: 6.00 MB

OK, but incomplete, skipped, or risky tests!
Tests: 89, Assertions: 106, Skipped: 2.
```
