### PR TITLE
Support deeper types in SchemaInspector

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.php text=auto

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,3 @@
-language: php
-php:
-  - '7.1'
-  - '7.2'
-  - '7.3'
-
 before_script:
   - composer install
 
@@ -12,4 +6,38 @@ script: vendor/phpunit/phpunit/phpunit tests/ --whitelist src/ --coverage-clover
 after_script:
   - php vendor/bin/codacycoverage clover build/coverage/xml
 
-os: linux
+_install_windows: &install_windows
+  install:
+    - choco install php --version $PHP_VERSION --no-progress --package-parameters='"/InstallDir:C:\tools\PHP"'
+    - choco install composer --no-progress --ia '"/DEV=C:\tools\php /PHP=C:\tools\php"'
+    - export PATH=$PATH:/C/tools/php
+
+_install_osx: &install_osx
+  install:
+    - brew unlink python@2
+    - brew install php@$PHP_VERSION
+    - brew install composer
+
+jobs:
+  include:
+    - os: linux
+      language: php
+      php: 7.1
+    - os: linux
+      language: php
+      php: 7.2
+    - os: linux
+      language: php
+      php: 7.3
+    - os: osx
+      language: sh
+      env: PHP_VERSION='7.2'
+      <<: *install_osx
+    - os: osx
+      language: sh
+      env: PHP_VERSION='7.3'
+      <<: *install_osx
+    - os: windows
+      language: sh
+      env: PHP_VERSION='7.3.9'
+      <<: *install_windows

--- a/src/SchemaGenerator/CodeGenerator/CodeFile/ClassFile.php
+++ b/src/SchemaGenerator/CodeGenerator/CodeFile/ClassFile.php
@@ -170,7 +170,7 @@ class %3$s
         $string = '';
         if (!empty($this->traits)) {
             foreach ($this->traits as $traitName => $nothing) {
-                $string .= "    use $traitName;\n";
+                $string .= "    use $traitName;" . PHP_EOL;
             }
         }
 
@@ -186,7 +186,7 @@ class %3$s
         if (!empty($this->constants)) {
             foreach ($this->constants as $name => $value) {
                 $value = $this->serializeParameterValue($value);
-                $string .= "    const $name = $value;\n";
+                $string .= "    const $name = $value;" . PHP_EOL;
             }
         }
 

--- a/src/SchemaGenerator/CodeGenerator/CodeFile/TraitFile.php
+++ b/src/SchemaGenerator/CodeGenerator/CodeFile/TraitFile.php
@@ -133,7 +133,7 @@ trait %3$s
     {
         $string = '';
         if (!empty($this->namespace)) {
-            $string = "namespace $this->namespace;\n";
+            $string = "namespace $this->namespace;" . PHP_EOL;
         }
 
         return $string;
@@ -147,7 +147,7 @@ trait %3$s
         $string = '';
         if (!empty($this->imports)) {
             foreach ($this->imports as $import => $nothing) {
-                $string .= "use $import;\n";
+                $string .= "use $import;" . PHP_EOL;
             }
         }
 
@@ -163,10 +163,10 @@ trait %3$s
         if (!empty($this->properties)) {
             foreach ($this->properties as $name => $value) {
                 if ($value === null) {
-                    $string .= "    protected $$name;\n";
+                    $string .= "    protected $$name;" . PHP_EOL;
                 } else {
                     $value = $this->serializeParameterValue($value);
-                    $string .= "    protected $$name = $value;\n";
+                    $string .= "    protected $$name = $value;" . PHP_EOL;
                 }
             }
         }

--- a/src/SchemaGenerator/SchemaInspector.php
+++ b/src/SchemaGenerator/SchemaInspector.php
@@ -27,6 +27,10 @@ type{
       ofType{
         name
         kind
+        ofType{
+          name
+          kind
+        }
       }
     }
   }

--- a/tests/AbstractCodeFileTest.php
+++ b/tests/AbstractCodeFileTest.php
@@ -39,7 +39,7 @@ class AbstractCodeFileTest extends CodeFileTestCase
             AbstractCodeFile::class,
             [static::getGeneratedFilesDir(), $this->fileName]
         );
-        $this->codeFile->method('generateFileContents')->willReturn("<?php\n");
+        $this->codeFile->method('generateFileContents')->willReturn("<?php" . PHP_EOL);
     }
 
     /**

--- a/tests/CodeFileTestCase.php
+++ b/tests/CodeFileTestCase.php
@@ -55,6 +55,7 @@ abstract class CodeFileTestCase extends TestCase
                 }
             }
         }
+        chmod($dirName, 0777);
         rmdir($dirName);
     }
 }

--- a/tests/SchemaClassGeneratorTest.php
+++ b/tests/SchemaClassGeneratorTest.php
@@ -44,13 +44,13 @@ class SchemaClassGeneratorTest extends CodeFileTestCase
         $this->classGenerator = new SchemaClassGenerator(
             new Client('')
         );
-        $this->assertStringEndsWith('/php-graphql-oqm/schema_object', $this->classGenerator->getWriteDir());
+        $this->assertStringEndsWith('php-graphql-oqm/schema_object', $this->classGenerator->getWriteDir());
 
         $this->classGenerator = new SchemaClassGenerator(
             new Client(''),
             static::getGeneratedFilesDir()
         );
-        $this->assertStringEndsWith('/tests/files_generated', $this->classGenerator->getWriteDir());
+        $this->assertStringEndsWith('tests/files_generated', $this->classGenerator->getWriteDir());
     }
 
     /**


### PR DESCRIPTION
This allows reading types like [Type!]!, which are 4 levels deep. Previously a `Reached the limit of nesting in type info` exception would be thrown.