### PR TITLE
generatedObjects array should cache more specific class name

### DIFF
--- a/src/SchemaGenerator/CodeGenerator/ArgumentsObjectClassBuilder.php
+++ b/src/SchemaGenerator/CodeGenerator/ArgumentsObjectClassBuilder.php
@@ -21,9 +21,7 @@ class ArgumentsObjectClassBuilder extends ObjectClassBuilder
      */
     public function __construct(string $writeDir, string $objectName, string $namespace = self::DEFAULT_NAMESPACE)
     {
-        $className = $objectName . 'ArgumentsObject';
-
-        $this->classFile = new ClassFile($writeDir, $className);
+        $this->classFile = new ClassFile($writeDir, $objectName);
         $this->classFile->setNamespace($namespace);
         if ($namespace !== self::DEFAULT_NAMESPACE) {
             $this->classFile->addImport('GraphQL\\SchemaObject\\ArgumentsObject');

--- a/src/SchemaGenerator/CodeGenerator/QueryObjectClassBuilder.php
+++ b/src/SchemaGenerator/CodeGenerator/QueryObjectClassBuilder.php
@@ -84,8 +84,7 @@ class QueryObjectClassBuilder extends ObjectClassBuilder
     protected function addObjectSelector(string $fieldName, string $upperCamelName, string $fieldTypeName, string $argsObjectName, bool $isDeprecated, ?string $deprecationReason)
     {
         $objectClassName  = $fieldTypeName . 'QueryObject';
-        $argsMapClassName = $argsObjectName . 'ArgumentsObject';
-        $method = "public function select$upperCamelName($argsMapClassName \$argsObject = null)
+        $method = "public function select$upperCamelName($argsObjectName \$argsObject = null)
 {
     \$object = new $objectClassName(\"$fieldName\");
     if (\$argsObject !== null) {

--- a/tests/ArgumentsObjectClassBuilderTest.php
+++ b/tests/ArgumentsObjectClassBuilderTest.php
@@ -32,9 +32,8 @@ class ArgumentsObjectClassBuilderTest extends CodeFileTestCase
      */
     public function testAddScalarArgument()
     {
-        $objectName = 'WithScalarArg';
+        $objectName = 'WithScalarArgArgumentsObject';
         $classBuilder = new ArgumentsObjectClassBuilder(static::getGeneratedFilesDir(), $objectName, static::TESTING_NAMESPACE);
-        $objectName .= 'ArgumentsObject';
         $classBuilder->addScalarArgument('scalarProperty');
         $classBuilder->build();
 
@@ -54,9 +53,8 @@ class ArgumentsObjectClassBuilderTest extends CodeFileTestCase
      */
     public function testAddMultipleScalarArguments()
     {
-        $objectName = 'WithMultipleScalarArgs';
+        $objectName = 'WithMultipleScalarArgsArgumentsObject';
         $classBuilder = new ArgumentsObjectClassBuilder(static::getGeneratedFilesDir(), $objectName, static::TESTING_NAMESPACE);
-        $objectName .= 'ArgumentsObject';
         $classBuilder->addScalarArgument('scalarProperty');
         $classBuilder->addScalarArgument('another_scalar_property');
         $classBuilder->build();
@@ -77,9 +75,8 @@ class ArgumentsObjectClassBuilderTest extends CodeFileTestCase
      */
     public function testAddListArgument()
     {
-        $objectName = 'WithListArg';
+        $objectName = 'WithListArgArgumentsObject';
         $classBuilder = new ArgumentsObjectClassBuilder(static::getGeneratedFilesDir(), $objectName, static::TESTING_NAMESPACE);
-        $objectName .= 'ArgumentsObject';
         $classBuilder->addListArgument('listProperty', 'string');
         $classBuilder->build();
 
@@ -99,9 +96,8 @@ class ArgumentsObjectClassBuilderTest extends CodeFileTestCase
      */
     public function testAddMultipleListArguments()
     {
-        $objectName = 'WithMultipleListArgs';
+        $objectName = 'WithMultipleListArgsArgumentsObject';
         $classBuilder = new ArgumentsObjectClassBuilder(static::getGeneratedFilesDir(), $objectName, static::TESTING_NAMESPACE);
-        $objectName .= 'ArgumentsObject';
         $classBuilder->addListArgument('listProperty', 'string');
         $classBuilder->addListArgument('another_list_property', 'string');
         $classBuilder->build();
@@ -122,9 +118,8 @@ class ArgumentsObjectClassBuilderTest extends CodeFileTestCase
      */
     public function testAddInputObjectArgument()
     {
-        $objectName = 'WithInputObjectArg';
+        $objectName = 'WithInputObjectArgArgumentsObject';
         $classBuilder = new ArgumentsObjectClassBuilder(static::getGeneratedFilesDir(), $objectName, static::TESTING_NAMESPACE);
-        $objectName .= 'ArgumentsObject';
         $classBuilder->addInputObjectArgument('objectProperty', 'Some');
         $classBuilder->build();
 
@@ -144,9 +139,8 @@ class ArgumentsObjectClassBuilderTest extends CodeFileTestCase
      */
     public function testAddMultipleInputObjectArguments()
     {
-        $objectName = 'WithMultipleInputObjectArgs';
+        $objectName = 'WithMultipleInputObjectArgsArgumentsObject';
         $classBuilder = new ArgumentsObjectClassBuilder(static::getGeneratedFilesDir(), $objectName, static::TESTING_NAMESPACE);
-        $objectName .= 'ArgumentsObject';
         $classBuilder->addInputObjectArgument('objectProperty', 'Some');
         $classBuilder->addInputObjectArgument('another_object_property', 'Another');
         $classBuilder->build();

--- a/tests/QueryObjectClassBuilderTest.php
+++ b/tests/QueryObjectClassBuilderTest.php
@@ -100,7 +100,7 @@ class QueryObjectClassBuilderTest extends CodeFileTestCase
         $objectName = 'ObjectSelector';
         $classBuilder = new QueryObjectClassBuilder(static::getGeneratedFilesDir(), $objectName, static::TESTING_NAMESPACE);
         $objectName .= 'QueryObject';
-        $classBuilder->addObjectField('others', 'Other', 'RootOthers', false, null);
+        $classBuilder->addObjectField('others', 'Other', 'RootOthersArgumentsObject', false, null);
         $classBuilder->build();
 
         $this->assertFileEquals(
@@ -120,8 +120,8 @@ class QueryObjectClassBuilderTest extends CodeFileTestCase
         $objectName = 'MultipleObjectSelectors';
         $classBuilder = new QueryObjectClassBuilder(static::getGeneratedFilesDir(), $objectName, static::TESTING_NAMESPACE);
         $objectName .= 'QueryObject';
-        $classBuilder->addObjectField('right_objects', 'Right', 'MultipleObjectSelectorsRightObjects', false, null);
-        $classBuilder->addObjectField('left_objects', 'Left', 'MultipleObjectSelectorsLeftObjects', true, null);
+        $classBuilder->addObjectField('right', 'MultipleObjectSelectorsRight', 'MultipleObjectSelectorsRightArgumentsObject', false, null);
+        $classBuilder->addObjectField('left_objects', 'Left', 'MultipleObjectSelectorsLeftObjectsArgumentsObject', true, null);
         $classBuilder->build();
 
         $this->assertFileEquals(

--- a/tests/SchemaClassGeneratorTest.php
+++ b/tests/SchemaClassGeneratorTest.php
@@ -413,7 +413,7 @@ class SchemaClassGeneratorTest extends CodeFileTestCase
      */
     public function testGenerateArgumentsObjectWithScalarArgs()
     {
-        $objectName = 'WithMultipleScalarArgs';
+        $objectName = 'WithMultipleScalarArgsArgumentsObject';
         $argsArray = [
             [
                 'name' => 'scalarProperty',
@@ -437,9 +437,8 @@ class SchemaClassGeneratorTest extends CodeFileTestCase
                 ]
             ]
         ];
-        $this->classGenerator->generateArgumentsObject('WithMultipleScalarArgs', $argsArray);
+        $this->classGenerator->generateArgumentsObject($objectName, $argsArray);
 
-        $objectName .= 'ArgumentsObject';
         $this->assertFileEquals(
             static::getExpectedFilesDir() . "/arguments_objects/$objectName.php",
             static::getGeneratedFilesDir() . "/$objectName.php"
@@ -452,7 +451,7 @@ class SchemaClassGeneratorTest extends CodeFileTestCase
      */
     public function testGenerateArgumentsObjectWithEnumArg()
     {
-        $objectName = 'WithMultipleEnumArg';
+        $objectName = 'WithMultipleEnumArgArgumentsObject';
         // Add mock responses
         $this->mockHandler->append(new Response(200, [], json_encode([
             'data' => [
@@ -481,9 +480,8 @@ class SchemaClassGeneratorTest extends CodeFileTestCase
                 ]
             ]
         ];
-        $this->classGenerator->generateArgumentsObject('WithMultipleEnumArg', $argsArray);
+        $this->classGenerator->generateArgumentsObject($objectName, $argsArray);
 
-        $objectName .= 'ArgumentsObject';
         $this->assertFileEquals(
             static::getExpectedFilesDir() . "/arguments_objects/$objectName.php",
             static::getGeneratedFilesDir() . "/$objectName.php"
@@ -496,7 +494,7 @@ class SchemaClassGeneratorTest extends CodeFileTestCase
      */
     public function testGenerateArgumentsObjectWithListArgs()
     {
-        $objectName = 'WithMultipleListArgs';
+        $objectName = 'WithMultipleListArgsArgumentsObject';
         // Add mock responses
         $this->mockHandler->append(new Response(200, [], json_encode([
             'data' => [
@@ -552,7 +550,6 @@ class SchemaClassGeneratorTest extends CodeFileTestCase
         ];
         $this->classGenerator->generateArgumentsObject($objectName, $argsArray);
 
-        $objectName .= 'ArgumentsObject';
         $this->assertFileEquals(
             static::getExpectedFilesDir() . "/arguments_objects/$objectName.php",
             static::getGeneratedFilesDir() . "/$objectName.php"
@@ -585,7 +582,7 @@ class SchemaClassGeneratorTest extends CodeFileTestCase
             ]
         ])));
 
-        $objectName = 'WithMultipleInputObjectArgs';
+        $objectName = 'WithMultipleInputObjectArgsArgumentsObject';
         $argsArray = [
             [
                 'name' => 'objectProperty',
@@ -611,7 +608,6 @@ class SchemaClassGeneratorTest extends CodeFileTestCase
         ];
         $this->classGenerator->generateArgumentsObject($objectName, $argsArray);
 
-        $objectName .= 'ArgumentsObject';
         $this->assertFileEquals(
             static::getExpectedFilesDir() . "/arguments_objects/$objectName.php",
             static::getGeneratedFilesDir() . "/$objectName.php"
@@ -721,7 +717,7 @@ class SchemaClassGeneratorTest extends CodeFileTestCase
                     'kind' => FieldTypeKindEnum::OBJECT,
                     'fields' => [
                         [
-                            'name' => 'right_objects',
+                            'name' => 'right',
                             'description' => null,
                             'isDeprecated' => false,
                             'deprecationReason' => null,
@@ -730,7 +726,7 @@ class SchemaClassGeneratorTest extends CodeFileTestCase
                                 'kind' => FieldTypeKindEnum::LIST,
                                 'description' => null,
                                 'ofType' => [
-                                    'name' => 'Right',
+                                    'name' => 'MultipleObjectSelectorsRight',
                                     'kind' => FieldTypeKindEnum::OBJECT,
                                     'description' => null,
                                     'ofType' => null,
@@ -762,7 +758,7 @@ class SchemaClassGeneratorTest extends CodeFileTestCase
         $this->mockHandler->append(new Response(200, [], json_encode([
             'data' => [
                 '__type' => [
-                    'name' => 'Right',
+                    'name' => 'MultipleObjectSelectorsRight',
                     'kind' => FieldTypeKindEnum::OBJECT,
                     'fields' => []
                 ]
@@ -784,6 +780,13 @@ class SchemaClassGeneratorTest extends CodeFileTestCase
             static::getExpectedFilesDir() . "/query_objects/$objectName.php",
             static::getGeneratedFilesDir() . "/$objectName.php"
         );
+        
+        // Test if the right classes are generated.
+        $this->assertFileExists(static::getGeneratedFilesDir() . "/LeftQueryObject.php", "The query object name for the left field should consist of the type name Left plus QueryObject");
+        $this->assertFileExists(static::getGeneratedFilesDir() . "/MultipleObjectSelectorsLeftObjectsArgumentsObject.php", "The argument object name for the left field should consist of the parent type name MultipleObjectSelectors plus the field name LeftObjects plus ArgumentsObject");
+
+        $this->assertFileExists(static::getGeneratedFilesDir() . "/MultipleObjectSelectorsRightQueryObject.php", "The query object name for the right field should consist of the type name MultipleObjectSelectorsRight plus QueryObject");
+        $this->assertFileExists(static::getGeneratedFilesDir() . "/MultipleObjectSelectorsRightArgumentsObject.php", "The argument object name for the right field should consist of the parent type name MultipleObjectSelectors plus the field name Right plus ArgumentsObject");
     }
 
     /**

--- a/tests/files_expected/query_objects/MultipleObjectSelectorsQueryObject.php
+++ b/tests/files_expected/query_objects/MultipleObjectSelectorsQueryObject.php
@@ -8,9 +8,9 @@ class MultipleObjectSelectorsQueryObject extends QueryObject
 {
     const OBJECT_NAME = "MultipleObjectSelectors";
 
-    public function selectRightObjects(MultipleObjectSelectorsRightObjectsArgumentsObject $argsObject = null)
+    public function selectRight(MultipleObjectSelectorsRightArgumentsObject $argsObject = null)
     {
-        $object = new RightQueryObject("right_objects");
+        $object = new MultipleObjectSelectorsRightQueryObject("right");
         if ($argsObject !== null) {
             $object->appendArguments($argsObject->toArray());
         }


### PR DESCRIPTION
In my schema I have a type `Special` with an object field `Status` of type `SpecialStatus`. This exact naming scheme causes a bug in the OQM because `$this->generatedObjects` contains just a part of the class name that is generated.

In `SchemaClassGenerator::appendQueryObjectFields()` first an object query class is generated and the name of the class is added to the `generatedObjects` array, causing `SpecialStatus` to be in the array. Later, the arguments class should be generated. It uses the concatenation of the parent class (ie `Special`) and the field name (`Status`) to check if the arguments have already been generated. As this element is already present in the array, the arguments object is not generated.

I think the full class name should be in the list.