### PR TITLE
Properly encode enum values when used as arguments

### DIFF
--- a/src/SchemaGenerator/CodeGenerator/ArgumentsObjectClassBuilder.php
+++ b/src/SchemaGenerator/CodeGenerator/ArgumentsObjectClassBuilder.php
@@ -56,6 +56,17 @@ class ArgumentsObjectClassBuilder extends ObjectClassBuilder
      * @param string $argumentName
      * @param string $typeName
      */
+    public function addInputEnumArgument(string $argumentName, string $typeName)
+    {
+        $upperCamelCaseArg = StringLiteralFormatter::formatUpperCamelCase($argumentName);
+        $this->addProperty($argumentName);
+        $this->addEnumSetter($argumentName, $upperCamelCaseArg, $typeName);
+    }
+
+    /**
+     * @param string $argumentName
+     * @param string $typeName
+     */
     public function addInputObjectArgument(string $argumentName, string $typeName)
     {
         $typeName .= 'InputObject';

--- a/src/SchemaGenerator/CodeGenerator/ObjectClassBuilder.php
+++ b/src/SchemaGenerator/CodeGenerator/ObjectClassBuilder.php
@@ -62,6 +62,24 @@ abstract class ObjectClassBuilder implements ObjectBuilderInterface
      * @param string $upperCamelName
      * @param string $objectClass
      */
+    protected function addEnumSetter(string $propertyName, string $upperCamelName, string $objectClass)
+    {
+        $lowerCamelName = lcfirst(str_replace('_', '', $objectClass));
+        $method         = "public function set$upperCamelName($$lowerCamelName)
+{
+    \$this->$propertyName = new RawObject($$lowerCamelName);
+
+    return \$this;
+}";
+        $this->classFile->addMethod($method);
+        $this->classFile->addImport('GraphQL\\RawObject');
+    }
+
+    /**
+     * @param string $propertyName
+     * @param string $upperCamelName
+     * @param string $objectClass
+     */
     protected function addObjectSetter(string $propertyName, string $upperCamelName, string $objectClass)
     {
         $lowerCamelName = lcfirst(str_replace('_', '', $objectClass));

--- a/src/SchemaGenerator/SchemaClassGenerator.php
+++ b/src/SchemaGenerator/SchemaClassGenerator.php
@@ -250,6 +250,8 @@ class SchemaClassGenerator
                 } else {
                     if ($typeKind === FieldTypeKindEnum::SCALAR) {
                         $objectBuilder->addScalarArgument($name);
+                    } elseif ($typeKind === FieldTypeKindEnum::ENUM_OBJECT) {
+                        $objectBuilder->addInputEnumArgument($name, $typeName);
                     } else {
                         $objectBuilder->addInputObjectArgument($name, $typeName);
                     }

--- a/tests/SchemaClassGeneratorTest.php
+++ b/tests/SchemaClassGeneratorTest.php
@@ -450,6 +450,50 @@ class SchemaClassGeneratorTest extends CodeFileTestCase
      * @covers \GraphQL\SchemaGenerator\SchemaClassGenerator::generateArgumentsObject
      * @covers \GraphQL\SchemaGenerator\SchemaClassGenerator::generateObject
      */
+    public function testGenerateArgumentsObjectWithEnumArg()
+    {
+        $objectName = 'WithMultipleEnumArg';
+        // Add mock responses
+        $this->mockHandler->append(new Response(200, [], json_encode([
+            'data' => [
+                '__type' => [
+                    'name' => 'Some',
+                    'kind' => FieldTypeKindEnum::ENUM_OBJECT,
+                    'enumValues' => [
+                        [
+                            'name' => 'some_value',
+                            'description' => null,
+                        ]
+                    ]
+                ]
+            ]
+        ])));
+        $argsArray  = [
+            [
+                'name' => 'enumProperty',
+                'description' => null,
+                'defaultValue' => null,
+                'type' => [
+                    'name' => 'Some',
+                    'kind' => FieldTypeKindEnum::ENUM_OBJECT,
+                    'description' => null,
+                    'ofType' => null,
+                ]
+            ]
+        ];
+        $this->classGenerator->generateArgumentsObject('WithMultipleEnumArg', $argsArray);
+
+        $objectName .= 'ArgumentsObject';
+        $this->assertFileEquals(
+            static::getExpectedFilesDir() . "/arguments_objects/$objectName.php",
+            static::getGeneratedFilesDir() . "/$objectName.php"
+        );
+    }
+
+    /**
+     * @covers \GraphQL\SchemaGenerator\SchemaClassGenerator::generateArgumentsObject
+     * @covers \GraphQL\SchemaGenerator\SchemaClassGenerator::generateObject
+     */
     public function testGenerateArgumentsObjectWithListArgs()
     {
         $objectName = 'WithMultipleListArgs';

--- a/tests/files_expected/arguments_objects/WithMultipleEnumArgArgumentsObject.php
+++ b/tests/files_expected/arguments_objects/WithMultipleEnumArgArgumentsObject.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace GraphQL\Tests\SchemaObject;
+
+use GraphQL\SchemaObject\ArgumentsObject;
+use GraphQL\RawObject;
+
+class WithMultipleEnumArgArgumentsObject extends ArgumentsObject
+{
+    protected $enumProperty;
+
+    public function setEnumProperty($some)
+    {
+        $this->enumProperty = new RawObject($some);
+    
+        return $this;
+    }
+}


### PR DESCRIPTION
When an enum field is used as argument it is currently represented like this:

```php
    public function setValue(ParentValueInputObject $parentValueInputObject)
    {
        $this->value = $parentValueInputObject;
    
        return $this;
    }
```

The `ParentValueInputObject` is never generated and I think this class is not needed.

This PR changes the code to:

```php
    /**
     * @var string $value
     */
    public function setValue($value)
    {
        $this->value = new RawObject($value);
    
        return $this;
    }
```

This causes the following graphql query:

```graphql
{
  query(value: THE_VALUE) {
  ...
}
```