### PR TITLE
Normalize line endings to generate consistent line endings on Windows

### DIFF
--- a/src/SchemaGenerator/CodeGenerator/CodeFile/ClassFile.php
+++ b/src/SchemaGenerator/CodeGenerator/CodeFile/ClassFile.php
@@ -125,7 +125,7 @@ class %3$s
         if (!empty($properties)) $properties = PHP_EOL . $properties;
         $methods = $this->generateMethods();
 
-        return sprintf(
+        $contents = sprintf(
             static::FILE_FORMAT,
             $namespace,
             $imports,
@@ -135,6 +135,7 @@ class %3$s
             $properties,
             $methods
         );
+        return $this->normalizeLineEndings($contents);
     }
 
     /**

--- a/src/SchemaGenerator/CodeGenerator/CodeFile/TraitFile.php
+++ b/src/SchemaGenerator/CodeGenerator/CodeFile/TraitFile.php
@@ -104,7 +104,11 @@ trait %3$s
     public function addMethod(string $methodString, bool $isDeprecated = false, ?string $deprecationReason = null)
     {
         if (!empty($methodString)) {
-            $this->methods[] = $this->prependDeprecationComment($methodString, $isDeprecated, $deprecationReason);
+            $methodString = $this->prependDeprecationComment($methodString, $isDeprecated, $deprecationReason);
+
+            // Normalize line endings here to make replacements in generateMethods() work.
+            $methodString = $this->normalizeLineEndings($methodString);
+            $this->methods[] = $methodString;
         }
     }
 
@@ -126,7 +130,8 @@ trait %3$s
         if (!empty($properties)) $properties = PHP_EOL . $properties;
         $methods = $this->generateMethods();
 
-        return sprintf(static::FILE_FORMAT, $namespace, $imports, $className, $properties, $methods);
+        $contents = sprintf(static::FILE_FORMAT, $namespace, $imports, $className, $properties, $methods);
+        return $this->normalizeLineEndings($contents);
     }
 
     /**
@@ -220,6 +225,16 @@ trait %3$s
  * @deprecated".($deprecationReason ? " $deprecationReason" : "")."
  */
 ".$code;
+        }
+
+        return $code;
+    }
+
+    protected function normalizeLineEndings(string $code)
+    {
+        $code = str_replace("\r", '', $code);
+        if (PHP_EOL !== "\n") {
+            $code = str_replace("\n", PHP_EOL, $code);
         }
 
         return $code;


### PR DESCRIPTION
As discussed in #15 this code normalizes the line endings of the output files to `PHP_EOL`. It also normalizes them in `addMethodString()` to make sure replacement patterns work predictably.