### PR TITLE
Add support for UNION object types

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -35,7 +35,7 @@
     "bin": ["bin/generate_schema_objects"],
     "require": {
         "php": "^7.1 || ^8.0",
-        "gmostafa/php-graphql-client": "^1.6 || ^1.9"
+        "gmostafa/php-graphql-client": "^1.12"
     },
     "require-dev": {
         "phpunit/phpunit": "^7.5|^8.0",

--- a/src/Enumeration/FieldTypeKindEnum.php
+++ b/src/Enumeration/FieldTypeKindEnum.php
@@ -15,4 +15,5 @@ class FieldTypeKindEnum
     const OBJECT       = 'OBJECT';
     const INPUT_OBJECT = 'INPUT_OBJECT';
     const ENUM_OBJECT  = 'ENUM';
+    const UNION_OBJECT = 'UNION';
 }

--- a/src/SchemaGenerator/CodeGenerator/QueryObjectClassBuilder.php
+++ b/src/SchemaGenerator/CodeGenerator/QueryObjectClassBuilder.php
@@ -2,6 +2,7 @@
 
 namespace GraphQL\SchemaGenerator\CodeGenerator;
 
+use GraphQL\Enumeration\FieldTypeKindEnum;
 use GraphQL\SchemaGenerator\CodeGenerator\CodeFile\ClassFile;
 use GraphQL\SchemaObject\QueryObject;
 use GraphQL\Util\StringLiteralFormatter;
@@ -50,12 +51,15 @@ class QueryObjectClassBuilder extends ObjectClassBuilder
     /**
      * @param string $fieldName
      * @param string $typeName
+     * @param string $typeKind
      * @param string $argsObjectName
+     * @param bool $isDeprecated
+     * @param string|null $deprecationReason
      */
-    public function addObjectField(string $fieldName, string $typeName, string $argsObjectName, bool $isDeprecated, ?string $deprecationReason)
+    public function addObjectField(string $fieldName, string $typeName, string $typeKind, string $argsObjectName, bool $isDeprecated, ?string $deprecationReason)
     {
         $upperCamelCaseProp = StringLiteralFormatter::formatUpperCamelCase($fieldName);
-        $this->addObjectSelector($fieldName, $upperCamelCaseProp, $typeName, $argsObjectName, $isDeprecated, $deprecationReason);
+        $this->addObjectSelector($fieldName, $upperCamelCaseProp, $typeName, $typeKind, $argsObjectName, $isDeprecated, $deprecationReason);
     }
 
     /**
@@ -79,14 +83,17 @@ class QueryObjectClassBuilder extends ObjectClassBuilder
      * @param string $fieldName
      * @param string $upperCamelName
      * @param string $fieldTypeName
+     * @param string $fieldTypeKind
      * @param string $argsObjectName
+     * @param bool $isDeprecated
+     * @param string|null $deprecationReason
      */
-    protected function addObjectSelector(string $fieldName, string $upperCamelName, string $fieldTypeName, string $argsObjectName, bool $isDeprecated, ?string $deprecationReason)
+    protected function addObjectSelector(string $fieldName, string $upperCamelName, string $fieldTypeName, string $fieldTypeKind, string $argsObjectName, bool $isDeprecated, ?string $deprecationReason)
     {
-        $objectClassName  = $fieldTypeName . 'QueryObject';
+        $objectClass = $fieldTypeName . ($fieldTypeKind === FieldTypeKindEnum::UNION_OBJECT ? 'UnionObject' : 'QueryObject');
         $method = "public function select$upperCamelName($argsObjectName \$argsObject = null)
 {
-    \$object = new $objectClassName(\"$fieldName\");
+    \$object = new $objectClass(\"$fieldName\");
     if (\$argsObject !== null) {
         \$object->appendArguments(\$argsObject->toArray());
     }

--- a/src/SchemaGenerator/CodeGenerator/UnionObjectBuilder.php
+++ b/src/SchemaGenerator/CodeGenerator/UnionObjectBuilder.php
@@ -1,0 +1,63 @@
+<?php
+
+namespace GraphQL\SchemaGenerator\CodeGenerator;
+
+use GraphQL\SchemaGenerator\CodeGenerator\CodeFile\ClassFile;
+use GraphQL\Util\StringLiteralFormatter;
+
+/**
+ * Class EnumObjectBuilder
+ *
+ * @package GraphQL\SchemaGenerator\CodeGenerator
+ */
+class UnionObjectBuilder implements ObjectBuilderInterface
+{
+    /**
+     * @var ClassFile
+     */
+    protected $classFile;
+
+    /**
+     * EnumObjectBuilder constructor.
+     *
+     * @param string $writeDir
+     * @param string $objectName
+     * @param string $namespace
+     */
+    public function __construct(string $writeDir, string $objectName, string $namespace = self::DEFAULT_NAMESPACE)
+    {
+        $className = $objectName . 'UnionObject';
+
+        $this->classFile = new ClassFile($writeDir, $className);
+        $this->classFile->setNamespace($namespace);
+        if ($namespace !== self::DEFAULT_NAMESPACE) {
+            $this->classFile->addImport('GraphQL\\SchemaObject\\UnionObject');
+        }
+        $this->classFile->extendsClass('UnionObject');
+    }
+
+    /**
+     * @param string $typeName
+     */
+    public function addPossibleType(string $typeName)
+    {
+        $upperCamelCaseTypeName = StringLiteralFormatter::formatUpperCamelCase($typeName);
+        $objectClassName = $typeName . 'QueryObject';
+        $method = "public function on$upperCamelCaseTypeName()
+{
+    \$object = new $objectClassName();
+    \$this->addPossibleType(\$object);
+
+    return \$object;
+}";
+        $this->classFile->addMethod($method);
+    }
+
+    /**
+     * @return void
+     */
+    public function build(): void
+    {
+        $this->classFile->writeFile();
+    }
+}

--- a/src/SchemaGenerator/SchemaInspector.php
+++ b/src/SchemaGenerator/SchemaInspector.php
@@ -161,4 +161,26 @@ QUERY;
 
         return $response->getData()['__type'];
     }
+
+    /**
+     * @param string $objectName
+     *
+     * @return array
+     */
+    public function getUnionObjectSchema(string $objectName): array
+    {
+        $schemaQuery = "{
+  __type(name: \"$objectName\") {
+    name
+    kind
+    possibleTypes {
+      kind
+      name
+    }
+  }
+}";
+        $response = $this->client->runRawQuery($schemaQuery, true);
+
+        return $response->getData()['__type'];
+    }
 }

--- a/src/SchemaObject/UnionObject.php
+++ b/src/SchemaObject/UnionObject.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace GraphQL\SchemaObject;
+
+use GraphQL\InlineFragment;
+use GraphQL\Query;
+
+/**
+ * Class UnionObject
+ *
+ * @package GraphQL\SchemaObject
+ */
+abstract class UnionObject extends QueryObject
+{
+    protected function addPossibleType(QueryObject $possibleType)
+    {
+        $fragment = new InlineFragment($possibleType::OBJECT_NAME, $possibleType);
+        $this->selectField($fragment);
+    }
+}

--- a/tests/QueryObjectClassBuilderTest.php
+++ b/tests/QueryObjectClassBuilderTest.php
@@ -2,6 +2,7 @@
 
 namespace GraphQL\Tests;
 
+use GraphQL\Enumeration\FieldTypeKindEnum;
 use GraphQL\SchemaGenerator\CodeGenerator\QueryObjectClassBuilder;
 use GraphQL\SchemaObject\QueryObject;
 
@@ -100,7 +101,7 @@ class QueryObjectClassBuilderTest extends CodeFileTestCase
         $objectName = 'ObjectSelector';
         $classBuilder = new QueryObjectClassBuilder(static::getGeneratedFilesDir(), $objectName, static::TESTING_NAMESPACE);
         $objectName .= 'QueryObject';
-        $classBuilder->addObjectField('others', 'Other', 'RootOthersArgumentsObject', false, null);
+        $classBuilder->addObjectField('others', 'Other', FieldTypeKindEnum::OBJECT, 'RootOthersArgumentsObject', false, null);
         $classBuilder->build();
 
         $this->assertFileEquals(
@@ -120,8 +121,8 @@ class QueryObjectClassBuilderTest extends CodeFileTestCase
         $objectName = 'MultipleObjectSelectors';
         $classBuilder = new QueryObjectClassBuilder(static::getGeneratedFilesDir(), $objectName, static::TESTING_NAMESPACE);
         $objectName .= 'QueryObject';
-        $classBuilder->addObjectField('right', 'MultipleObjectSelectorsRight', 'MultipleObjectSelectorsRightArgumentsObject', false, null);
-        $classBuilder->addObjectField('left_objects', 'Left', 'MultipleObjectSelectorsLeftObjectsArgumentsObject', true, null);
+        $classBuilder->addObjectField('right', 'MultipleObjectSelectorsRight', FieldTypeKindEnum::OBJECT, 'MultipleObjectSelectorsRightArgumentsObject', false, null);
+        $classBuilder->addObjectField('left_objects', 'Left', FieldTypeKindEnum::OBJECT, 'MultipleObjectSelectorsLeftObjectsArgumentsObject', true, null);
         $classBuilder->build();
 
         $this->assertFileEquals(

--- a/tests/UnionObjectTest.php
+++ b/tests/UnionObjectTest.php
@@ -1,0 +1,91 @@
+<?php
+
+namespace GraphQL\Tests;
+
+use GraphQL\Query;
+use GraphQL\SchemaObject\QueryObject;
+use GraphQL\SchemaObject\UnionObject;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Class QueryObjectTest
+ *
+ * @package GraphQL\Tests
+ */
+class UnionObjectTest extends TestCase
+{
+    /**
+     * @covers \GraphQL\SchemaObject\UnionObject
+     */
+    public function testUnionObject()
+    {
+        $object = new SimpleUnionObject('union');
+        $object->onType1()->selectScalar();
+        $object->onType2()->selectAnotherScalar();
+        $this->assertEquals(
+            'query {
+union {
+... on Type1 {
+scalar
+}
+... on Type2 {
+anotherScalar
+}
+}
+}',
+            (string) $object->getQuery());
+    }
+}
+
+class SimpleUnionObject extends UnionObject
+{
+    const OBJECT_NAME = 'Simple';
+
+
+
+    public function onType1()
+    {
+        $object = new Type1QueryObject();
+
+        $this->addPossibleType($object);
+
+        return $object;
+    }
+
+    public function onType2()
+    {
+        $object = new Type2QueryObject();
+
+        $this->addPossibleType($object);
+
+        return $object;
+    }
+}
+
+abstract class SimpleSubTypeQueryObject extends QueryObject
+{
+    public function selectScalar()
+    {
+        $this->selectField('scalar');
+
+        return $this;
+    }
+
+    public function selectAnotherScalar()
+    {
+        $this->selectField('anotherScalar');
+
+        return $this;
+    }
+}
+
+class Type1QueryObject extends SimpleSubTypeQueryObject
+{
+    const OBJECT_NAME = 'Type1';
+}
+
+class Type2QueryObject extends SimpleSubTypeQueryObject
+{
+    const OBJECT_NAME = 'Type2';
+}
+

--- a/tests/files_expected/union_objects/UnionObject1QueryObject.php
+++ b/tests/files_expected/union_objects/UnionObject1QueryObject.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace GraphQL\Tests\SchemaObject;
+
+use GraphQL\SchemaObject\QueryObject;
+
+class UnionObject1QueryObject extends QueryObject
+{
+    const OBJECT_NAME = "UnionObject1";
+
+    public function selectUnion(UnionObject1UnionArgumentsObject $argsObject = null)
+    {
+        $object = new UnionTestObjectUnionObject("union");
+        if ($argsObject !== null) {
+            $object->appendArguments($argsObject->toArray());
+        }
+        $this->selectField($object);
+
+        return $object;
+    }
+}

--- a/tests/files_expected/union_objects/UnionObject2QueryObject.php
+++ b/tests/files_expected/union_objects/UnionObject2QueryObject.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace GraphQL\Tests\SchemaObject;
+
+use GraphQL\SchemaObject\QueryObject;
+
+class UnionObject2QueryObject extends QueryObject
+{
+    const OBJECT_NAME = "UnionObject2";
+}

--- a/tests/files_expected/union_objects/UnionTestObjectUnionObject.php
+++ b/tests/files_expected/union_objects/UnionTestObjectUnionObject.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace GraphQL\Tests\SchemaObject;
+
+use GraphQL\SchemaObject\UnionObject;
+
+class UnionTestObjectUnionObject extends UnionObject
+{
+    public function onUnionObject1()
+    {
+        $object = new UnionObject1QueryObject();
+        $this->addPossibleType($object);
+
+        return $object;
+    }
+
+    public function onUnionObject2()
+    {
+        $object = new UnionObject2QueryObject();
+        $this->addPossibleType($object);
+
+        return $object;
+    }
+}


### PR DESCRIPTION
This needs https://github.com/mghoneimy/php-graphql-client/pull/58.

The result of this change is that the following code becomes possible:

```php
$rootQuery = new RootQueryObject();

$ufield = $rootQuery->selectUnionField();
$ufield->onPossibleType1()->selectFieldOnTheFirstType();
$ufield->onPossibleType2()->selectFieldOnTheSecondType();
```