### PR TITLE
Remove usage of removed EmptySelectionSetException

### DIFF
--- a/src/SchemaObject/QueryObject.php
+++ b/src/SchemaObject/QueryObject.php
@@ -2,7 +2,6 @@
 
 namespace GraphQL\SchemaObject;
 
-use GraphQL\Exception\EmptySelectionSetException;
 use GraphQL\Query;
 use GraphQL\QueryBuilder\AbstractQueryBuilder;
 

--- a/tests/QueryObjectTest.php
+++ b/tests/QueryObjectTest.php
@@ -2,7 +2,6 @@
 
 namespace GraphQL\Tests;
 
-use GraphQL\Exception\EmptySelectionSetException;
 use GraphQL\SchemaObject\ArgumentsObject;
 use GraphQL\SchemaObject\InputObject;
 use GraphQL\SchemaObject\QueryObject;
@@ -53,16 +52,6 @@ scalar
 }
 }',
             (string) $object->getQuery());
-    }
-
-    /**
-     * @covers \GraphQL\SchemaObject\QueryObject::__construct
-     * @covers \GraphQL\Exception\EmptySelectionSetException
-     */
-    public function testEmptySelectionSet()
-    {
-        $this->expectException(EmptySelectionSetException::class);
-        $this->queryObject->getQuery();
     }
 
     /**


### PR DESCRIPTION
In php-graphql-client the class EmptySelectionSetException was removed. It is still referenced by php-graphql-oqm.