### PR TITLE
Don't generate empty argument objects

### DIFF
--- a/README.md
+++ b/README.md
@@ -252,7 +252,7 @@ class RootQueryObject extends QueryObject
 {
     const OBJECT_NAME = "query";
 
-    public function selectPokemons(RootPokemonsArgumentsObject $argsObject = null)
+    public function selectPokemons(?RootPokemonsArgumentsObject $argsObject = null)
     {
         $object = new PokemonQueryObject("pokemons");
         if ($argsObject !== null) {
@@ -263,7 +263,7 @@ class RootQueryObject extends QueryObject
         return $object;
     }
 
-    public function selectPokemon(RootPokemonArgumentsObject $argsObject = null)
+    public function selectPokemon(?RootPokemonArgumentsObject $argsObject = null)
     {
         $object = new PokemonQueryObject("pokemon");
         if ($argsObject !== null) {
@@ -359,7 +359,7 @@ class PokemonQueryObject extends QueryObject
         return $this;
     }
 
-    public function selectWeight(PokemonWeightArgumentsObject $argsObject = null)
+    public function selectWeight(?PokemonWeightArgumentsObject $argsObject = null)
     {
         $object = new PokemonDimensionQueryObject("weight");
         if ($argsObject !== null) {
@@ -370,7 +370,7 @@ class PokemonQueryObject extends QueryObject
         return $object;
     }
 
-    public function selectHeight(PokemonHeightArgumentsObject $argsObject = null)
+    public function selectHeight(?PokemonHeightArgumentsObject $argsObject = null)
     {
         $object = new PokemonDimensionQueryObject("height");
         if ($argsObject !== null) {
@@ -402,7 +402,7 @@ class PokemonQueryObject extends QueryObject
         return $this;
     }
 
-    public function selectAttacks(PokemonAttacksArgumentsObject $argsObject = null)
+    public function selectAttacks(?PokemonAttacksArgumentsObject $argsObject = null)
     {
         $object = new PokemonAttackQueryObject("attacks");
         if ($argsObject !== null) {
@@ -434,7 +434,7 @@ class PokemonQueryObject extends QueryObject
         return $this;
     }
 
-    public function selectEvolutions(PokemonEvolutionsArgumentsObject $argsObject = null)
+    public function selectEvolutions(?PokemonEvolutionsArgumentsObject $argsObject = null)
     {
         $object = new PokemonQueryObject("evolutions");
         if ($argsObject !== null) {
@@ -445,7 +445,7 @@ class PokemonQueryObject extends QueryObject
         return $object;
     }
 
-    public function selectEvolutionRequirements(PokemonEvolutionRequirementsArgumentsObject $argsObject = null)
+    public function selectEvolutionRequirements(?PokemonEvolutionRequirementsArgumentsObject $argsObject = null)
     {
         $object = new PokemonEvolutionRequirementQueryObject("evolutionRequirements");
         if ($argsObject !== null) {

--- a/README.md
+++ b/README.md
@@ -252,7 +252,7 @@ class RootQueryObject extends QueryObject
 {
     const OBJECT_NAME = "query";
 
-    public function selectPokemons(?RootPokemonsArgumentsObject $argsObject = null)
+    public function selectPokemons(?RootPokemonsArgumentsObject $argsObject = null): PokemonQueryObject
     {
         $object = new PokemonQueryObject("pokemons");
         if ($argsObject !== null) {
@@ -263,7 +263,7 @@ class RootQueryObject extends QueryObject
         return $object;
     }
 
-    public function selectPokemon(?RootPokemonArgumentsObject $argsObject = null)
+    public function selectPokemon(?RootPokemonArgumentsObject $argsObject = null): PokemonQueryObject
     {
         $object = new PokemonQueryObject("pokemon");
         if ($argsObject !== null) {
@@ -287,7 +287,7 @@ class RootPokemonsArgumentsObject extends ArgumentsObject
 {
     protected $first;
 
-    public function setFirst($first)
+    public function setFirst($first): self
     {
         $this->first = $first;
     
@@ -308,14 +308,14 @@ class RootPokemonArgumentsObject extends ArgumentsObject
     protected $id;
     protected $name;
 
-    public function setId($id)
+    public function setId($id): self
     {
         $this->id = $id;
     
         return $this;
     }
 
-    public function setName($name)
+    public function setName($name): self
     {
         $this->name = $name;
     
@@ -338,28 +338,28 @@ class PokemonQueryObject extends QueryObject
 {
     const OBJECT_NAME = "Pokemon";
 
-    public function selectId()
+    public function selectId(): self
     {
         $this->selectField("id");
     
         return $this;
     }
 
-    public function selectNumber()
+    public function selectNumber(): self
     {
         $this->selectField("number");
     
         return $this;
     }
 
-    public function selectName()
+    public function selectName(): self
     {
         $this->selectField("name");
     
         return $this;
     }
 
-    public function selectWeight(?PokemonWeightArgumentsObject $argsObject = null)
+    public function selectWeight(?PokemonWeightArgumentsObject $argsObject = null): PokemonDimensionQueryObject
     {
         $object = new PokemonDimensionQueryObject("weight");
         if ($argsObject !== null) {
@@ -370,7 +370,7 @@ class PokemonQueryObject extends QueryObject
         return $object;
     }
 
-    public function selectHeight(?PokemonHeightArgumentsObject $argsObject = null)
+    public function selectHeight(?PokemonHeightArgumentsObject $argsObject = null): PokemonDimensionQueryObject
     {
         $object = new PokemonDimensionQueryObject("height");
         if ($argsObject !== null) {
@@ -381,28 +381,28 @@ class PokemonQueryObject extends QueryObject
         return $object;
     }
 
-    public function selectClassification()
+    public function selectClassification(): self
     {
         $this->selectField("classification");
     
         return $this;
     }
 
-    public function selectTypes()
+    public function selectTypes(): self
     {
         $this->selectField("types");
     
         return $this;
     }
 
-    public function selectResistant()
+    public function selectResistant(): self
     {
         $this->selectField("resistant");
     
         return $this;
     }
 
-    public function selectAttacks(?PokemonAttacksArgumentsObject $argsObject = null)
+    public function selectAttacks(?PokemonAttacksArgumentsObject $argsObject = null): PokemonAttackQueryObject
     {
         $object = new PokemonAttackQueryObject("attacks");
         if ($argsObject !== null) {
@@ -413,28 +413,28 @@ class PokemonQueryObject extends QueryObject
         return $object;
     }
 
-    public function selectWeaknesses()
+    public function selectWeaknesses(): self
     {
         $this->selectField("weaknesses");
     
         return $this;
     }
 
-    public function selectFleeRate()
+    public function selectFleeRate(): self
     {
         $this->selectField("fleeRate");
     
         return $this;
     }
 
-    public function selectMaxCP()
+    public function selectMaxCP(): self
     {
         $this->selectField("maxCP");
     
         return $this;
     }
 
-    public function selectEvolutions(?PokemonEvolutionsArgumentsObject $argsObject = null)
+    public function selectEvolutions(?PokemonEvolutionsArgumentsObject $argsObject = null): PokemonQueryObject
     {
         $object = new PokemonQueryObject("evolutions");
         if ($argsObject !== null) {
@@ -445,7 +445,7 @@ class PokemonQueryObject extends QueryObject
         return $object;
     }
 
-    public function selectEvolutionRequirements(?PokemonEvolutionRequirementsArgumentsObject $argsObject = null)
+    public function selectEvolutionRequirements(?PokemonEvolutionRequirementsArgumentsObject $argsObject = null): PokemonEvolutionRequirementQueryObject
     {
         $object = new PokemonEvolutionRequirementQueryObject("evolutionRequirements");
         if ($argsObject !== null) {
@@ -456,14 +456,14 @@ class PokemonQueryObject extends QueryObject
         return $object;
     }
 
-    public function selectMaxHP()
+    public function selectMaxHP(): self
     {
         $this->selectField("maxHP");
     
         return $this;
     }
 
-    public function selectImage()
+    public function selectImage(): self
     {
         $this->selectField("image");
     

--- a/README.md
+++ b/README.md
@@ -250,7 +250,7 @@ namespace GraphQL\SchemaObject;
 
 class RootQueryObject extends QueryObject
 {
-    const OBJECT_NAME = "query";
+    public const OBJECT_NAME = "query";
 
     public function selectPokemons(?RootPokemonsArgumentsObject $argsObject = null): PokemonQueryObject
     {
@@ -336,7 +336,7 @@ namespace GraphQL\SchemaObject;
 
 class PokemonQueryObject extends QueryObject
 {
-    const OBJECT_NAME = "Pokemon";
+    public const OBJECT_NAME = "Pokemon";
 
     public function selectId(): self
     {

--- a/src/Enumeration/FieldTypeKindEnum.php
+++ b/src/Enumeration/FieldTypeKindEnum.php
@@ -9,11 +9,12 @@ namespace GraphQL\Enumeration;
  */
 class FieldTypeKindEnum
 {
-    const SCALAR       = 'SCALAR';
-    const LIST         = 'LIST';
-    const NON_NULL     = 'NON_NULL';
-    const OBJECT       = 'OBJECT';
-    const INPUT_OBJECT = 'INPUT_OBJECT';
-    const ENUM_OBJECT  = 'ENUM';
-    const UNION_OBJECT = 'UNION';
+    const SCALAR           = 'SCALAR';
+    const LIST             = 'LIST';
+    const NON_NULL         = 'NON_NULL';
+    const OBJECT           = 'OBJECT';
+    const INPUT_OBJECT     = 'INPUT_OBJECT';
+    const ENUM_OBJECT      = 'ENUM';
+    const UNION_OBJECT     = 'UNION';
+    const INTERFACE_OBJECT = 'INTERFACE';
 }

--- a/src/SchemaGenerator/CodeGenerator/CodeFile/ClassFile.php
+++ b/src/SchemaGenerator/CodeGenerator/CodeFile/ClassFile.php
@@ -188,7 +188,7 @@ class %3$s
         if (!empty($this->constants)) {
             foreach ($this->constants as $name => $value) {
                 $value = $this->serializeParameterValue($value);
-                $string .= "    const $name = $value;" . PHP_EOL;
+                $string .= "    public const $name = $value;" . PHP_EOL;
             }
         }
 

--- a/src/SchemaGenerator/CodeGenerator/InterfaceObjectBuilder.php
+++ b/src/SchemaGenerator/CodeGenerator/InterfaceObjectBuilder.php
@@ -1,0 +1,60 @@
+<?php
+
+namespace GraphQL\SchemaGenerator\CodeGenerator;
+
+use GraphQL\SchemaGenerator\CodeGenerator\CodeFile\ClassFile;
+use GraphQL\Util\StringLiteralFormatter;
+
+/**
+ * Class InterfaceObjectBuilder
+ *
+ * @package GraphQL\SchemaGenerator\CodeGenerator
+ */
+class InterfaceObjectBuilder extends QueryObjectClassBuilder
+{
+    /**
+     * @var ClassFile
+     */
+    protected $classFile;
+
+    /**
+     * EnumObjectBuilder constructor.
+     *
+     * @param string $writeDir
+     * @param string $objectName
+     * @param string $namespace
+     */
+    public function __construct(string $writeDir, string $objectName, string $namespace = self::DEFAULT_NAMESPACE)
+    {
+        $className = $objectName . 'QueryObject';
+
+        $this->classFile = new ClassFile($writeDir, $className);
+        $this->classFile->setNamespace($namespace);
+        if ($namespace !== self::DEFAULT_NAMESPACE) {
+            $this->classFile->addImport('GraphQL\\SchemaObject\\InterfaceObject');
+        }
+        $this->classFile->extendsClass('InterfaceObject');
+    }
+
+    /**
+     * @param string $typeName
+     */
+    public function addImplementation(string $typeName)
+    {
+        $upperCamelCaseTypeName = StringLiteralFormatter::formatUpperCamelCase($typeName);
+        $objectClassName = $typeName . 'QueryObject';
+        $method = "public function on$upperCamelCaseTypeName(): $objectClassName
+{
+    return \$this->addImplementation($objectClassName::class);
+}";
+        $this->classFile->addMethod($method);
+    }
+
+    /**
+     * @return void
+     */
+    public function build(): void
+    {
+        $this->classFile->writeFile();
+    }
+}

--- a/src/SchemaGenerator/CodeGenerator/ObjectClassBuilder.php
+++ b/src/SchemaGenerator/CodeGenerator/ObjectClassBuilder.php
@@ -31,7 +31,7 @@ abstract class ObjectClassBuilder implements ObjectBuilderInterface
     protected function addScalarSetter($propertyName, $upperCamelName)
     {
         $lowerCamelName = lcfirst($upperCamelName);
-        $method = "public function set$upperCamelName($$lowerCamelName)
+        $method = "public function set$upperCamelName($$lowerCamelName): self
 {
     \$this->$propertyName = $$lowerCamelName;
 
@@ -48,7 +48,7 @@ abstract class ObjectClassBuilder implements ObjectBuilderInterface
     protected function addListSetter(string $propertyName, string $upperCamelName, string $propertyType)
     {
         $lowerCamelName = lcfirst($upperCamelName);
-        $method = "public function set$upperCamelName(array $$lowerCamelName)
+        $method = "public function set$upperCamelName(array $$lowerCamelName): self
 {
     \$this->$propertyName = $$lowerCamelName;
 
@@ -65,7 +65,7 @@ abstract class ObjectClassBuilder implements ObjectBuilderInterface
     protected function addEnumSetter(string $propertyName, string $upperCamelName, string $objectClass)
     {
         $lowerCamelName = lcfirst(str_replace('_', '', $objectClass));
-        $method         = "public function set$upperCamelName($$lowerCamelName)
+        $method         = "public function set$upperCamelName($$lowerCamelName): self
 {
     \$this->$propertyName = new RawObject($$lowerCamelName);
 
@@ -83,7 +83,7 @@ abstract class ObjectClassBuilder implements ObjectBuilderInterface
     protected function addObjectSetter(string $propertyName, string $upperCamelName, string $objectClass)
     {
         $lowerCamelName = lcfirst(str_replace('_', '', $objectClass));
-        $method         = "public function set$upperCamelName($objectClass $$lowerCamelName)
+        $method         = "public function set$upperCamelName($objectClass $$lowerCamelName): self
 {
     \$this->$propertyName = $$lowerCamelName;
 

--- a/src/SchemaGenerator/CodeGenerator/QueryObjectClassBuilder.php
+++ b/src/SchemaGenerator/CodeGenerator/QueryObjectClassBuilder.php
@@ -125,7 +125,7 @@ class QueryObjectClassBuilder extends ObjectClassBuilder
     return \$object;
 }";
         } else {
-            $method = "public function $methodName($argsObjectName \$argsObject = null)
+            $method = "public function $methodName(?$argsObjectName \$argsObject = null)
 {
     \$object = new $objectClass(\"$fieldName\");
     if (\$argsObject !== null) {

--- a/src/SchemaGenerator/CodeGenerator/QueryObjectClassBuilder.php
+++ b/src/SchemaGenerator/CodeGenerator/QueryObjectClassBuilder.php
@@ -85,7 +85,7 @@ class QueryObjectClassBuilder extends ObjectClassBuilder
     }
 
     /**
-     * @param string $propertyName
+     * @param string $fieldName
      * @param string $upperCamelName
      * @param bool $isDeprecated
      * @param string|null $deprecationReason
@@ -93,7 +93,7 @@ class QueryObjectClassBuilder extends ObjectClassBuilder
     protected function addSimpleSelector(string $fieldName, string $upperCamelName, bool $isDeprecated, ?string $deprecationReason)
     {
         $methodName = $this->isRootMutation ? $fieldName : 'select' . $upperCamelName;
-        $method = "public function $methodName()
+        $method = "public function $methodName(): self
 {
     \$this->selectField(\"$fieldName\");
 
@@ -117,7 +117,7 @@ class QueryObjectClassBuilder extends ObjectClassBuilder
         $objectClass = $fieldTypeName . ($fieldTypeKind === FieldTypeKindEnum::UNION_OBJECT ? 'UnionObject' : 'QueryObject');
 
         if ($argsObjectName === null) {
-            $method = "public function $methodName()
+            $method = "public function $methodName(): $objectClass
 {
     \$object = new $objectClass(\"$fieldName\");
     \$this->selectField(\$object);
@@ -125,7 +125,7 @@ class QueryObjectClassBuilder extends ObjectClassBuilder
     return \$object;
 }";
         } else {
-            $method = "public function $methodName(?$argsObjectName \$argsObject = null)
+            $method = "public function $methodName(?$argsObjectName \$argsObject = null): $objectClass
 {
     \$object = new $objectClass(\"$fieldName\");
     if (\$argsObject !== null) {

--- a/src/SchemaGenerator/CodeGenerator/QueryObjectClassBuilder.php
+++ b/src/SchemaGenerator/CodeGenerator/QueryObjectClassBuilder.php
@@ -3,6 +3,7 @@
 namespace GraphQL\SchemaGenerator\CodeGenerator;
 
 use GraphQL\Enumeration\FieldTypeKindEnum;
+use GraphQL\Mutation;
 use GraphQL\SchemaGenerator\CodeGenerator\CodeFile\ClassFile;
 use GraphQL\SchemaObject\QueryObject;
 use GraphQL\Util\StringLiteralFormatter;
@@ -15,6 +16,11 @@ use GraphQL\Util\StringLiteralFormatter;
 class QueryObjectClassBuilder extends ObjectClassBuilder
 {
     /**
+     * @var bool
+     */
+    private $isRootMutation = false;
+
+    /**
      * QueryObjectClassBuilder constructor.
      *
      * @param string $writeDir
@@ -23,7 +29,13 @@ class QueryObjectClassBuilder extends ObjectClassBuilder
      */
     public function __construct(string $writeDir, string $objectName, string $namespace = self::DEFAULT_NAMESPACE)
     {
-        $className = $objectName . 'QueryObject';
+        if ($objectName === QueryObject::ROOT_MUTATION_OBJECT_NAME) {
+            $objectName = '';
+            $className = 'RootMutationObject';
+            $this->isRootMutation = true;
+        } else {
+            $className = $objectName . 'QueryObject';
+        }
 
         $this->classFile = new ClassFile($writeDir, $className);
         $this->classFile->setNamespace($namespace);
@@ -37,6 +49,16 @@ class QueryObjectClassBuilder extends ObjectClassBuilder
             $objectName = '';
         }
         $this->classFile->addConstant('OBJECT_NAME', $objectName);
+
+        if ($this->isRootMutation) {
+            $this->classFile->addImport(Mutation::class);
+            $constructor = 'public function __construct()
+{
+    parent::__construct();
+    $this->query = new Mutation();
+}';
+            $this->classFile->addMethod($constructor);
+        }
     }
 
     /**
@@ -68,11 +90,12 @@ class QueryObjectClassBuilder extends ObjectClassBuilder
      * @param bool $isDeprecated
      * @param string|null $deprecationReason
      */
-    protected function addSimpleSelector(string $propertyName, string $upperCamelName, bool $isDeprecated, ?string $deprecationReason)
+    protected function addSimpleSelector(string $fieldName, string $upperCamelName, bool $isDeprecated, ?string $deprecationReason)
     {
-        $method = "public function select$upperCamelName()
+        $methodName = $this->isRootMutation ? $fieldName : 'select' . $upperCamelName;
+        $method = "public function $methodName()
 {
-    \$this->selectField(\"$propertyName\");
+    \$this->selectField(\"$fieldName\");
 
     return \$this;
 }";
@@ -90,10 +113,11 @@ class QueryObjectClassBuilder extends ObjectClassBuilder
      */
     protected function addObjectSelector(string $fieldName, string $upperCamelName, string $fieldTypeName, string $fieldTypeKind, ?string $argsObjectName, bool $isDeprecated, ?string $deprecationReason)
     {
+        $methodName = $this->isRootMutation ? $fieldName : 'select' . $upperCamelName;
         $objectClass = $fieldTypeName . ($fieldTypeKind === FieldTypeKindEnum::UNION_OBJECT ? 'UnionObject' : 'QueryObject');
 
         if ($argsObjectName === null) {
-            $method = "public function select$upperCamelName()
+            $method = "public function $methodName()
 {
     \$object = new $objectClass(\"$fieldName\");
     \$this->selectField(\$object);
@@ -101,7 +125,7 @@ class QueryObjectClassBuilder extends ObjectClassBuilder
     return \$object;
 }";
         } else {
-            $method = "public function select$upperCamelName($argsObjectName \$argsObject = null)
+            $method = "public function $methodName($argsObjectName \$argsObject = null)
 {
     \$object = new $objectClass(\"$fieldName\");
     if (\$argsObject !== null) {

--- a/src/SchemaGenerator/CodeGenerator/UnionObjectBuilder.php
+++ b/src/SchemaGenerator/CodeGenerator/UnionObjectBuilder.php
@@ -43,7 +43,7 @@ class UnionObjectBuilder implements ObjectBuilderInterface
     {
         $upperCamelCaseTypeName = StringLiteralFormatter::formatUpperCamelCase($typeName);
         $objectClassName = $typeName . 'QueryObject';
-        $method = "public function on$upperCamelCaseTypeName()
+        $method = "public function on$upperCamelCaseTypeName(): $objectClassName
 {
     \$object = new $objectClassName();
     \$this->addPossibleType(\$object);

--- a/src/SchemaGenerator/SchemaClassGenerator.php
+++ b/src/SchemaGenerator/SchemaClassGenerator.php
@@ -112,12 +112,17 @@ class SchemaClassGenerator
                 // Generate nested type object if it wasn't generated
                 $objectGenerated = $this->generateObject($typeName, $typeKind);
                 if ($objectGenerated) {
+                    $arguments = $fieldArray['args'] ?? [];
+                    if (empty($arguments)) {
+                        $argsObjectName = null;
+                        $argsObjectGenerated = true;
+                    } else {
+                        // Generate nested type arguments object if it wasn't generated
+                        $argsObjectName = $currentTypeName . StringLiteralFormatter::formatUpperCamelCase($name) . 'ArgumentsObject';
+                        $argsObjectGenerated = $this->generateArgumentsObject($argsObjectName, $fieldArray['args'] ?? []);
+                    }
 
-                    // Generate nested type arguments object if it wasn't generated
-                    $argsObjectName = $currentTypeName . StringLiteralFormatter::formatUpperCamelCase($name) . 'ArgumentsObject';
-                    $argsObjectGenerated = $this->generateArgumentsObject($argsObjectName, $fieldArray['args'] ?? []);
                     if ($argsObjectGenerated) {
-
                         // Add sub type as a field to the query object if all generation happened successfully
                         $queryObjectBuilder->addObjectField($name, $typeName, $typeKind, $argsObjectName, $fieldArray['isDeprecated'], $fieldArray['deprecationReason']);
                     }

--- a/src/SchemaGenerator/SchemaClassGenerator.php
+++ b/src/SchemaGenerator/SchemaClassGenerator.php
@@ -9,6 +9,7 @@ use GraphQL\SchemaGenerator\CodeGenerator\EnumObjectBuilder;
 use GraphQL\SchemaGenerator\CodeGenerator\InputObjectClassBuilder;
 use GraphQL\SchemaGenerator\CodeGenerator\InterfaceObjectBuilder;
 use GraphQL\SchemaGenerator\CodeGenerator\ObjectBuilderInterface;
+use GraphQL\SchemaGenerator\CodeGenerator\ObjectClassBuilder;
 use GraphQL\SchemaGenerator\CodeGenerator\QueryObjectClassBuilder;
 use GraphQL\SchemaGenerator\CodeGenerator\UnionObjectBuilder;
 use GraphQL\SchemaObject\QueryObject;
@@ -32,12 +33,12 @@ class SchemaClassGenerator
     /**
      * @var string
      */
-	private $writeDir;
+    private $writeDir;
 
     /**
      * @var string
      */
-	private $generationNamespace;
+    private $generationNamespace;
 
     /**
      * This array is used as a set to store the already generated objects
@@ -54,24 +55,31 @@ class SchemaClassGenerator
      * @param string $writeDir
      * @param string $namespace
      */
-	public function __construct(Client $client, string $writeDir = '', string $namespace = ObjectBuilderInterface::DEFAULT_NAMESPACE)
+    public function __construct(Client $client, string $writeDir = '', string $namespace = ObjectBuilderInterface::DEFAULT_NAMESPACE)
     {
-        $this->schemaInspector     = new SchemaInspector($client);
-        $this->generatedObjects    = [];
-        $this->writeDir            = $writeDir;
+        $this->schemaInspector = new SchemaInspector($client);
+        $this->generatedObjects = [];
+        $this->writeDir = $writeDir;
         $this->generationNamespace = $namespace;
         $this->setWriteDir();
+    }
+
+    public function generateRootObjects(): bool
+    {
+        $this->generateRootQueryObject();
+        $this->generateRootMutationObject();
+
+        return true;
     }
 
     /**
      * @return bool
      */
-	public function generateRootQueryObject(): bool
-	{
-	    $objectArray    = $this->schemaInspector->getQueryTypeSchema();
+    public function generateRootQueryObject(): bool
+    {
+        $objectArray = $this->schemaInspector->getRootSchema('query');
         $rootObjectName = QueryObject::ROOT_QUERY_OBJECT_NAME;
-        $queryTypeName  = $objectArray['name'];
-        //$rootObjectDescr = $objectArray['description'];
+        $queryTypeName = $objectArray['name'];
 
         if (array_key_exists($queryTypeName, $this->generatedObjects)) {
             return true;
@@ -80,7 +88,29 @@ class SchemaClassGenerator
         $this->generatedObjects[$queryTypeName] = true;
 
         $queryObjectBuilder = new QueryObjectClassBuilder($this->writeDir, $rootObjectName, $this->generationNamespace);
-        $this->appendQueryObjectFields($queryObjectBuilder, $rootObjectName, $objectArray['fields']);
+        $this->appendObjectFields($queryObjectBuilder, $rootObjectName, $objectArray['fields']);
+        $queryObjectBuilder->build();
+
+        return true;
+    }
+
+    /**
+     * @return bool
+     */
+    public function generateRootMutationObject(): bool
+    {
+        $objectArray = $this->schemaInspector->getRootSchema('mutation');
+        $rootObjectName = QueryObject::ROOT_MUTATION_OBJECT_NAME;
+        $queryTypeName = $objectArray['name'];
+
+        if (array_key_exists($queryTypeName, $this->generatedObjects)) {
+            return true;
+        }
+
+        $this->generatedObjects[$queryTypeName] = true;
+
+        $queryObjectBuilder = new QueryObjectClassBuilder($this->writeDir, $rootObjectName, $this->generationNamespace);
+        $this->appendObjectFields($queryObjectBuilder, $rootObjectName, $objectArray['fields']);
         $queryObjectBuilder->build();
 
         return true;
@@ -89,18 +119,17 @@ class SchemaClassGenerator
     /**
      * This method receives the array of object fields as an input and adds the fields to the query object building
      *
-     * @param QueryObjectClassBuilder $queryObjectBuilder
-     * @param string                  $currentTypeName
-     * @param array                   $fieldsArray
+     * @param ObjectClassBuilder $queryObjectBuilder
+     * @param string $currentTypeName
+     * @param array $fieldsArray
      */
-	private function appendQueryObjectFields(QueryObjectClassBuilder $queryObjectBuilder, string $currentTypeName, array $fieldsArray)
+    private function appendObjectFields(ObjectClassBuilder $queryObjectBuilder, string $currentTypeName, array $fieldsArray)
     {
         foreach ($fieldsArray as $fieldArray) {
             $name = $fieldArray['name'];
-            // Skip fields with name "query"
-            if ($name === 'query') continue;
+            // Skip fields with name "query" or "field"
+            if ($name === 'query' || $name === 'field') continue;
 
-            //$description = $fieldArray['description'];
             [$typeName, $typeKind] = $this->getTypeInfo($fieldArray);
 
             if ($typeKind === FieldTypeKindEnum::SCALAR) {
@@ -168,8 +197,8 @@ class SchemaClassGenerator
         }
 
         $this->generatedObjects[$objectName] = true;
-        $objectArray   = $this->schemaInspector->getObjectSchema($objectName);
-        $objectName    = $objectArray['name'];
+        $objectArray = $this->schemaInspector->getObjectSchema($objectName);
+        $objectName = $objectArray['name'];
 
         if ($objectArray['kind'] === FieldTypeKindEnum::INTERFACE_OBJECT) {
             $objectBuilder = new InterfaceObjectBuilder($this->writeDir, $objectName, $this->generationNamespace);
@@ -180,7 +209,7 @@ class SchemaClassGenerator
             $objectBuilder = new QueryObjectClassBuilder($this->writeDir, $objectName, $this->generationNamespace);
         }
 
-        $this->appendQueryObjectFields($objectBuilder, $objectName, $objectArray['fields']);
+        $this->appendObjectFields($objectBuilder, $objectName, $objectArray['fields']);
         $objectBuilder->build();
 
         return true;
@@ -198,8 +227,8 @@ class SchemaClassGenerator
         }
 
         $this->generatedObjects[$objectName] = true;
-        $objectArray   = $this->schemaInspector->getInputObjectSchema($objectName);
-        $objectName    = $objectArray['name'];
+        $objectArray = $this->schemaInspector->getInputObjectSchema($objectName);
+        $objectName = $objectArray['name'];
         $objectBuilder = new InputObjectClassBuilder($this->writeDir, $objectName, $this->generationNamespace);
 
         foreach ($objectArray['inputFields'] as $inputFieldArray) {
@@ -244,12 +273,12 @@ class SchemaClassGenerator
 
         $this->generatedObjects[$objectName] = true;
 
-        $objectArray   = $this->schemaInspector->getEnumObjectSchema($objectName);
-        $objectName    = $objectArray['name'];
+        $objectArray = $this->schemaInspector->getEnumObjectSchema($objectName);
+        $objectName = $objectArray['name'];
         $objectBuilder = new EnumObjectBuilder($this->writeDir, $objectName, $this->generationNamespace);
 
         foreach ($objectArray['enumValues'] as $enumValue) {
-            $name        = $enumValue['name'];
+            $name = $enumValue['name'];
             //$description = $enumValue['description'];
             $objectBuilder->addEnumValue($name);
         }
@@ -271,8 +300,8 @@ class SchemaClassGenerator
 
         $this->generatedObjects[$objectName] = true;
 
-        $objectArray   = $this->schemaInspector->getUnionObjectSchema($objectName);
-        $objectName    = $objectArray['name'];
+        $objectArray = $this->schemaInspector->getUnionObjectSchema($objectName);
+        $objectName = $objectArray['name'];
         $objectBuilder = new UnionObjectBuilder($this->writeDir, $objectName, $this->generationNamespace);
 
         foreach ($objectArray['possibleTypes'] as $possibleType) {
@@ -297,8 +326,8 @@ class SchemaClassGenerator
 
         $this->generatedObjects[$objectName] = true;
 
-        $objectArray   = $this->schemaInspector->getObjectSchema($objectName);
-        $objectName    = $objectArray['name'];
+        $objectArray = $this->schemaInspector->getObjectSchema($objectName);
+        $objectName = $objectArray['name'];
         $objectBuilder = new UnionObjectBuilder($this->writeDir, $objectName, $this->generationNamespace);
 
         foreach ($objectArray['possibleTypes'] as $possibleType) {
@@ -312,7 +341,7 @@ class SchemaClassGenerator
 
     /**
      * @param string $argsObjectName
-     * @param array  $arguments
+     * @param array $arguments
      *
      * @return bool
      */
@@ -382,7 +411,7 @@ class SchemaClassGenerator
     /**
      * Sets the write directory if it's not set for the class
      */
-	private function setWriteDir(): void
+    private function setWriteDir(): void
     {
         if ($this->writeDir !== '') return;
 

--- a/src/SchemaGenerator/SchemaInspector.php
+++ b/src/SchemaGenerator/SchemaInspector.php
@@ -96,6 +96,10 @@ QUERY;
   __type(name: \"$objectName\") {
     name
     kind
+    possibleTypes {
+      kind
+      name
+    }
     fields(includeDeprecated: true){
       name
       description

--- a/src/SchemaGenerator/SchemaInspector.php
+++ b/src/SchemaGenerator/SchemaInspector.php
@@ -54,13 +54,14 @@ QUERY;
     }
 
     /**
+     * @param string $type query or mutation
      * @return array
      */
-    public function getQueryTypeSchema(): array
+    public function getRootSchema(string $type): array
     {
         $schemaQuery = "{
   __schema{
-    queryType{
+    ${type}Type{
       name
       kind
       description
@@ -82,7 +83,7 @@ QUERY;
 }";
         $response = $this->client->runRawQuery($schemaQuery, true);
 
-        return $response->getData()['__schema']['queryType'];
+        return $response->getData()['__schema'][$type.'Type'];
     }
 
     /**

--- a/src/SchemaGenerator/SchemaInspector.php
+++ b/src/SchemaGenerator/SchemaInspector.php
@@ -61,7 +61,7 @@ QUERY;
     {
         $schemaQuery = "{
   __schema{
-    ${type}Type{
+    {$type}Type{
       name
       kind
       description

--- a/src/SchemaObject/InterfaceObject.php
+++ b/src/SchemaObject/InterfaceObject.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace GraphQL\SchemaObject;
+
+use GraphQL\InlineFragment;
+
+/**
+ * Class InterfaceObject
+ *
+ * @package GraphQL\SchemaObject
+ */
+abstract class InterfaceObject extends QueryObject
+{
+    private $implementations = [];
+
+    protected function addImplementation(string $implementationTypeClassName)
+    {
+        if (!isset($this->implementations[$implementationTypeClassName])) {
+            $implementationType = new $implementationTypeClassName();
+            $fragment = new InlineFragment($implementationType::OBJECT_NAME, $implementationType);
+            $this->selectField($fragment);
+            $this->implementations[$implementationTypeClassName] = $implementationType;
+        }
+
+        return $this->implementations[$implementationTypeClassName];
+    }
+}

--- a/src/SchemaObject/QueryObject.php
+++ b/src/SchemaObject/QueryObject.php
@@ -22,6 +22,13 @@ abstract class QueryObject extends AbstractQueryBuilder
     public const ROOT_QUERY_OBJECT_NAME = 'Root';
 
     /**
+     * This constant stores the name to be given to the root query object
+     *
+     * @var  string
+     */
+    public const ROOT_MUTATION_OBJECT_NAME = 'RootMutation';
+
+    /**
      * This constant stores the name of the object name in the API definition
      *
      * @var string

--- a/src/SchemaObject/QueryObject.php
+++ b/src/SchemaObject/QueryObject.php
@@ -33,7 +33,7 @@ abstract class QueryObject extends AbstractQueryBuilder
      *
      * @var string
      */
-    protected const OBJECT_NAME = '';
+    public const OBJECT_NAME = '';
 
     /**
      * SchemaObject constructor.

--- a/tests/InterfaceObjectTest.php
+++ b/tests/InterfaceObjectTest.php
@@ -1,0 +1,84 @@
+<?php
+
+namespace GraphQL\Tests;
+
+use GraphQL\SchemaObject\QueryObject;
+use GraphQL\SchemaObject\InterfaceObject;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Class QueryObjectTest
+ *
+ * @package GraphQL\Tests
+ */
+class InterfaceObjectTest extends TestCase
+{
+    /**
+     * @covers \GraphQL\SchemaObject\InterfaceObject
+     */
+    public function testInterfaceObject()
+    {
+        $object = new SimpleInterfaceObject('interface');
+        $object->onType1()->selectScalar();
+        $object->onType2()->selectAnotherScalar();
+        $object->onType2()->selectScalar();
+        $this->assertEquals(
+            'query {
+interface {
+... on Type1 {
+scalar
+}
+... on Type2 {
+anotherScalar
+scalar
+}
+}
+}',
+            (string) $object->getQuery());
+    }
+}
+
+class SimpleInterfaceObject extends InterfaceObject
+{
+    const OBJECT_NAME = 'Simple';
+
+
+
+    public function onType1(): InterfaceType1QueryObject
+    {
+        return $this->addImplementation(InterfaceType1QueryObject::class);
+    }
+
+    public function onType2(): InterfaceType2QueryObject
+    {
+        return $this->addImplementation(InterfaceType2QueryObject::class);
+    }
+}
+
+abstract class InterfaceSimpleSubTypeQueryObject extends QueryObject
+{
+    public function selectScalar()
+    {
+        $this->selectField('scalar');
+
+        return $this;
+    }
+
+    public function selectAnotherScalar()
+    {
+        $this->selectField('anotherScalar');
+
+        return $this;
+    }
+}
+
+class InterfaceType1QueryObject extends InterfaceSimpleSubTypeQueryObject
+{
+    const OBJECT_NAME = 'Type1';
+}
+
+class InterfaceType2QueryObject extends InterfaceSimpleSubTypeQueryObject
+{
+    const OBJECT_NAME = 'Type2';
+}
+

--- a/tests/InterfaceObjectTest.php
+++ b/tests/InterfaceObjectTest.php
@@ -40,7 +40,7 @@ scalar
 
 class SimpleInterfaceObject extends InterfaceObject
 {
-    const OBJECT_NAME = 'Simple';
+    public const OBJECT_NAME = 'Simple';
 
 
 
@@ -74,11 +74,11 @@ abstract class InterfaceSimpleSubTypeQueryObject extends QueryObject
 
 class InterfaceType1QueryObject extends InterfaceSimpleSubTypeQueryObject
 {
-    const OBJECT_NAME = 'Type1';
+    public const OBJECT_NAME = 'Type1';
 }
 
 class InterfaceType2QueryObject extends InterfaceSimpleSubTypeQueryObject
 {
-    const OBJECT_NAME = 'Type2';
+    public const OBJECT_NAME = 'Type2';
 }
 

--- a/tests/QueryObjectClassBuilderTest.php
+++ b/tests/QueryObjectClassBuilderTest.php
@@ -121,8 +121,8 @@ class QueryObjectClassBuilderTest extends CodeFileTestCase
         $objectName = 'MultipleObjectSelectors';
         $classBuilder = new QueryObjectClassBuilder(static::getGeneratedFilesDir(), $objectName, static::TESTING_NAMESPACE);
         $objectName .= 'QueryObject';
-        $classBuilder->addObjectField('right', 'MultipleObjectSelectorsRight', FieldTypeKindEnum::OBJECT, 'MultipleObjectSelectorsRightArgumentsObject', false, null);
-        $classBuilder->addObjectField('left_objects', 'Left', FieldTypeKindEnum::OBJECT, 'MultipleObjectSelectorsLeftObjectsArgumentsObject', true, null);
+        $classBuilder->addObjectField('right', 'MultipleObjectSelectorsRight', FieldTypeKindEnum::OBJECT, null, false, null);
+        $classBuilder->addObjectField('left_objects', 'Left', FieldTypeKindEnum::OBJECT, null, true, null);
         $classBuilder->build();
 
         $this->assertFileEquals(

--- a/tests/QueryObjectTest.php
+++ b/tests/QueryObjectTest.php
@@ -145,7 +145,7 @@ scalar
 
 class SimpleQueryObject extends QueryObject
 {
-    const OBJECT_NAME = 'Simple';
+    public const OBJECT_NAME = 'Simple';
 
     public function selectScalar()
     {

--- a/tests/SchemaClassGeneratorTest.php
+++ b/tests/SchemaClassGeneratorTest.php
@@ -887,6 +887,104 @@ class SchemaClassGeneratorTest extends CodeFileTestCase
         );
     }
 
+    /**
+     * @covers \GraphQL\SchemaGenerator\SchemaClassGenerator::generateInterfaceObject
+     */
+    public function testGenerateInterfaceObject()
+    {
+        $objectName = 'TestInterface';
+
+        // Add mock responses
+        $this->mockHandler->append(new Response(200, [], json_encode([
+            'data' => [
+                '__type' => [
+                    'name' => 'InterfaceObject1',
+                    'kind' => FieldTypeKindEnum::OBJECT,
+                    'interfaces' => [
+                        ['name' => $objectName],
+                    ],
+                    'fields' => [
+                        [
+                            'name' => 'value',
+                            'description' => null,
+                            'isDeprecated' => false,
+                            'deprecationReason' => null,
+                            'type' => [
+                                'name' => 'String',
+                                'kind' => FieldTypeKindEnum::SCALAR,
+                                'description' => null,
+                                'ofType' => null,
+                            ],
+                            'args' => null,
+                        ],
+                    ],
+                ]
+            ]
+        ])));
+        $this->mockHandler->append(new Response(200, [], json_encode([
+            'data' => [
+                '__type' => [
+                    'name' => $objectName,
+                    'kind' => FieldTypeKindEnum::INTERFACE_OBJECT,
+                    'fields' => [
+                        [
+                            'name' => 'interface_field',
+                            'description' => null,
+                            'isDeprecated' => false,
+                            'deprecationReason' => null,
+                            'type' => [
+                                'name' => 'String',
+                                'kind' => FieldTypeKindEnum::SCALAR,
+                                'description' => null,
+                                'ofType' => null,
+                            ],
+                            'args' => null,
+                        ]
+                    ],
+                    'possibleTypes' => [
+                        [
+                            'kind' => FieldTypeKindEnum::OBJECT,
+                            'name' => 'InterfaceObject1',
+                        ], [
+                            'kind' => FieldTypeKindEnum::OBJECT,
+                            'name' => 'InterfaceObject2',
+                        ],
+                    ]
+                ]
+            ]
+        ])));
+        $this->mockHandler->append(new Response(200, [], json_encode([
+            'data' => [
+                '__type' => [
+                    'name' => 'InterfaceObject2',
+                    'kind' => FieldTypeKindEnum::OBJECT,
+                    'interfaces' => [
+                        ['name' => $objectName],
+                    ],
+                    'fields' => [],
+                ]
+            ]
+        ])));
+
+        $this->classGenerator->generateObject('InterfaceObject1', FieldTypeKindEnum::INTERFACE_OBJECT);
+        $this->classGenerator->generateObject($objectName, FieldTypeKindEnum::INTERFACE_OBJECT);
+        $this->classGenerator->generateObject('InterfaceObject2', FieldTypeKindEnum::INTERFACE_OBJECT);
+
+        $objectName .= 'QueryObject';
+        $this->assertFileEquals(
+            static::getExpectedFilesDir() . "/interface_objects/InterfaceObject1QueryObject.php",
+            static::getGeneratedFilesDir() . "/InterfaceObject1QueryObject.php"
+        );
+        $this->assertFileEquals(
+            static::getExpectedFilesDir() . "/interface_objects/InterfaceObject2QueryObject.php",
+            static::getGeneratedFilesDir() . "/InterfaceObject2QueryObject.php"
+        );
+        $this->assertFileEquals(
+            static::getExpectedFilesDir() . "/interface_objects/$objectName.php",
+            static::getGeneratedFilesDir() . "/$objectName.php"
+        );
+    }
+
     ///**
     // * @covers \GraphQL\SchemaGenerator\SchemaClassGenerator::generateObject
     // */

--- a/tests/SchemaClassGeneratorTest.php
+++ b/tests/SchemaClassGeneratorTest.php
@@ -783,10 +783,8 @@ class SchemaClassGeneratorTest extends CodeFileTestCase
 
         // Test if the right classes are generated.
         $this->assertFileExists(static::getGeneratedFilesDir() . "/LeftQueryObject.php", "The query object name for the left field should consist of the type name Left plus QueryObject");
-        $this->assertFileExists(static::getGeneratedFilesDir() . "/MultipleObjectSelectorsLeftObjectsArgumentsObject.php", "The argument object name for the left field should consist of the parent type name MultipleObjectSelectors plus the field name LeftObjects plus ArgumentsObject");
 
         $this->assertFileExists(static::getGeneratedFilesDir() . "/MultipleObjectSelectorsRightQueryObject.php", "The query object name for the right field should consist of the type name MultipleObjectSelectorsRight plus QueryObject");
-        $this->assertFileExists(static::getGeneratedFilesDir() . "/MultipleObjectSelectorsRightArgumentsObject.php", "The argument object name for the right field should consist of the parent type name MultipleObjectSelectors plus the field name Right plus ArgumentsObject");
     }
 
     /**

--- a/tests/SchemaClassGeneratorTest.php
+++ b/tests/SchemaClassGeneratorTest.php
@@ -616,7 +616,7 @@ class SchemaClassGeneratorTest extends CodeFileTestCase
 
     /**
      * @covers \GraphQL\SchemaGenerator\SchemaClassGenerator::generateQueryObject
-     * @covers \GraphQL\SchemaGenerator\SchemaClassGenerator::appendQueryObjectFields
+     * @covers \GraphQL\SchemaGenerator\SchemaClassGenerator::appendObjectFields
      * @covers \GraphQL\SchemaGenerator\SchemaClassGenerator::generateObject
      */
     public function testGenerateQueryObjectWithScalarFields()
@@ -703,7 +703,7 @@ class SchemaClassGeneratorTest extends CodeFileTestCase
 
     /**
      * @covers \GraphQL\SchemaGenerator\SchemaClassGenerator::generateQueryObject
-     * @covers \GraphQL\SchemaGenerator\SchemaClassGenerator::appendQueryObjectFields
+     * @covers \GraphQL\SchemaGenerator\SchemaClassGenerator::appendObjectFields
      * @covers \GraphQL\SchemaGenerator\SchemaClassGenerator::generateObject
      */
     public function testGenerateQueryObjectWithObjectFields()
@@ -790,7 +790,7 @@ class SchemaClassGeneratorTest extends CodeFileTestCase
     /**
      * @covers \GraphQL\SchemaGenerator\SchemaClassGenerator::generateRootQueryObject
      */
-    public function testGenerateRootObject()
+    public function testGenerateRootQueryObject()
     {
         $this->mockHandler->append(new Response(200, [], json_encode([
             'data' => [
@@ -809,6 +809,32 @@ class SchemaClassGeneratorTest extends CodeFileTestCase
         $objectName = 'RootQueryObject';
         $this->assertFileEquals(
             static::getExpectedFilesDir() . "/query_objects/$objectName.php",
+            static::getGeneratedFilesDir() . "/$objectName.php"
+        );
+    }
+
+    /**
+     * @covers \GraphQL\SchemaGenerator\SchemaClassGenerator::generateRootQueryObject
+     */
+    public function testGenerateRootMutationObject()
+    {
+        $this->mockHandler->append(new Response(200, [], json_encode([
+            'data' => [
+                '__schema' => [
+                    'mutationType' => [
+                        'name' => 'Mutation',
+                        'kind' => FieldTypeKindEnum::OBJECT,
+                        'description' => null,
+                        'fields' => []
+                    ]
+                ]
+            ]
+        ])));
+        $this->classGenerator->generateRootMutationObject();
+
+        $objectName = 'RootMutationObject';
+        $this->assertFileEquals(
+            static::getExpectedFilesDir() . "/mutation_objects/$objectName.php",
             static::getGeneratedFilesDir() . "/$objectName.php"
         );
     }
@@ -1008,6 +1034,11 @@ class TransparentSchemaClassGenerator extends SchemaClassGenerator
     public function generateRootQueryObject(): bool
     {
         return parent::generateRootQueryObject();
+    }
+
+    public function generateRootMutationObject(): bool
+    {
+        return parent::generateRootMutationObject();
     }
 
     public function generateQueryObject(string $objectName): bool

--- a/tests/UnionObjectTest.php
+++ b/tests/UnionObjectTest.php
@@ -45,7 +45,7 @@ class SimpleUnionObject extends UnionObject
 
     public function onType1()
     {
-        $object = new Type1QueryObject();
+        $object = new UnionType1QueryObject();
 
         $this->addPossibleType($object);
 
@@ -54,7 +54,7 @@ class SimpleUnionObject extends UnionObject
 
     public function onType2()
     {
-        $object = new Type2QueryObject();
+        $object = new UnionType2QueryObject();
 
         $this->addPossibleType($object);
 
@@ -62,7 +62,7 @@ class SimpleUnionObject extends UnionObject
     }
 }
 
-abstract class SimpleSubTypeQueryObject extends QueryObject
+abstract class UnionSimpleSubTypeQueryObject extends QueryObject
 {
     public function selectScalar()
     {
@@ -79,12 +79,12 @@ abstract class SimpleSubTypeQueryObject extends QueryObject
     }
 }
 
-class Type1QueryObject extends SimpleSubTypeQueryObject
+class UnionType1QueryObject extends UnionSimpleSubTypeQueryObject
 {
     const OBJECT_NAME = 'Type1';
 }
 
-class Type2QueryObject extends SimpleSubTypeQueryObject
+class UnionType2QueryObject extends UnionSimpleSubTypeQueryObject
 {
     const OBJECT_NAME = 'Type2';
 }

--- a/tests/UnionObjectTest.php
+++ b/tests/UnionObjectTest.php
@@ -39,7 +39,7 @@ anotherScalar
 
 class SimpleUnionObject extends UnionObject
 {
-    const OBJECT_NAME = 'Simple';
+    public const OBJECT_NAME = 'Simple';
 
 
 
@@ -81,11 +81,11 @@ abstract class UnionSimpleSubTypeQueryObject extends QueryObject
 
 class UnionType1QueryObject extends UnionSimpleSubTypeQueryObject
 {
-    const OBJECT_NAME = 'Type1';
+    public const OBJECT_NAME = 'Type1';
 }
 
 class UnionType2QueryObject extends UnionSimpleSubTypeQueryObject
 {
-    const OBJECT_NAME = 'Type2';
+    public const OBJECT_NAME = 'Type2';
 }
 

--- a/tests/files_expected/arguments_objects/WithInputObjectArgArgumentsObject.php
+++ b/tests/files_expected/arguments_objects/WithInputObjectArgArgumentsObject.php
@@ -8,7 +8,7 @@ class WithInputObjectArgArgumentsObject extends ArgumentsObject
 {
     protected $objectProperty;
 
-    public function setObjectProperty(SomeInputObject $someInputObject)
+    public function setObjectProperty(SomeInputObject $someInputObject): self
     {
         $this->objectProperty = $someInputObject;
 

--- a/tests/files_expected/arguments_objects/WithListArgArgumentsObject.php
+++ b/tests/files_expected/arguments_objects/WithListArgArgumentsObject.php
@@ -8,7 +8,7 @@ class WithListArgArgumentsObject extends ArgumentsObject
 {
     protected $listProperty;
 
-    public function setListProperty(array $listProperty)
+    public function setListProperty(array $listProperty): self
     {
         $this->listProperty = $listProperty;
 

--- a/tests/files_expected/arguments_objects/WithMultipleEnumArgArgumentsObject.php
+++ b/tests/files_expected/arguments_objects/WithMultipleEnumArgArgumentsObject.php
@@ -9,7 +9,7 @@ class WithMultipleEnumArgArgumentsObject extends ArgumentsObject
 {
     protected $enumProperty;
 
-    public function setEnumProperty($some)
+    public function setEnumProperty($some): self
     {
         $this->enumProperty = new RawObject($some);
 

--- a/tests/files_expected/arguments_objects/WithMultipleInputObjectArgsArgumentsObject.php
+++ b/tests/files_expected/arguments_objects/WithMultipleInputObjectArgsArgumentsObject.php
@@ -9,14 +9,14 @@ class WithMultipleInputObjectArgsArgumentsObject extends ArgumentsObject
     protected $objectProperty;
     protected $another_object_property;
 
-    public function setObjectProperty(SomeInputObject $someInputObject)
+    public function setObjectProperty(SomeInputObject $someInputObject): self
     {
         $this->objectProperty = $someInputObject;
 
         return $this;
     }
 
-    public function setAnotherObjectProperty(AnotherInputObject $anotherInputObject)
+    public function setAnotherObjectProperty(AnotherInputObject $anotherInputObject): self
     {
         $this->another_object_property = $anotherInputObject;
 

--- a/tests/files_expected/arguments_objects/WithMultipleListArgsArgumentsObject.php
+++ b/tests/files_expected/arguments_objects/WithMultipleListArgsArgumentsObject.php
@@ -9,14 +9,14 @@ class WithMultipleListArgsArgumentsObject extends ArgumentsObject
     protected $listProperty;
     protected $another_list_property;
 
-    public function setListProperty(array $listProperty)
+    public function setListProperty(array $listProperty): self
     {
         $this->listProperty = $listProperty;
 
         return $this;
     }
 
-    public function setAnotherListProperty(array $anotherListProperty)
+    public function setAnotherListProperty(array $anotherListProperty): self
     {
         $this->another_list_property = $anotherListProperty;
 

--- a/tests/files_expected/arguments_objects/WithMultipleScalarArgsArgumentsObject.php
+++ b/tests/files_expected/arguments_objects/WithMultipleScalarArgsArgumentsObject.php
@@ -9,14 +9,14 @@ class WithMultipleScalarArgsArgumentsObject extends ArgumentsObject
     protected $scalarProperty;
     protected $another_scalar_property;
 
-    public function setScalarProperty($scalarProperty)
+    public function setScalarProperty($scalarProperty): self
     {
         $this->scalarProperty = $scalarProperty;
 
         return $this;
     }
 
-    public function setAnotherScalarProperty($anotherScalarProperty)
+    public function setAnotherScalarProperty($anotherScalarProperty): self
     {
         $this->another_scalar_property = $anotherScalarProperty;
 

--- a/tests/files_expected/arguments_objects/WithScalarArgArgumentsObject.php
+++ b/tests/files_expected/arguments_objects/WithScalarArgArgumentsObject.php
@@ -8,7 +8,7 @@ class WithScalarArgArgumentsObject extends ArgumentsObject
 {
     protected $scalarProperty;
 
-    public function setScalarProperty($scalarProperty)
+    public function setScalarProperty($scalarProperty): self
     {
         $this->scalarProperty = $scalarProperty;
 

--- a/tests/files_expected/classes/ClassWithConstant.php
+++ b/tests/files_expected/classes/ClassWithConstant.php
@@ -2,5 +2,5 @@
 
 class ClassWithConstant
 {
-    const CONST_ONE = "ONE";
+    public const CONST_ONE = "ONE";
 }

--- a/tests/files_expected/classes/ClassWithEverything.php
+++ b/tests/files_expected/classes/ClassWithEverything.php
@@ -13,8 +13,8 @@ class ClassWithEverything extends Base implements Intr1, Intr2
     use Trait1;
     use Trait2;
 
-    const CONST_ONE = 1;
-    const CONST_TWO = "";
+    public const CONST_ONE = 1;
+    public const CONST_TWO = "";
 
     protected $propertyOne;
     protected $propertyTwo = "";

--- a/tests/files_expected/classes/ClassWithMultipleConstants.php
+++ b/tests/files_expected/classes/ClassWithMultipleConstants.php
@@ -2,10 +2,10 @@
 
 class ClassWithMultipleConstants
 {
-    const CONST_ONE = "ONE";
-    const CONST_TWO = 2;
-    const CONST_THEE = true;
-    const CONST_FOUR = false;
-    const CONST_FIVE = "";
-    const CONST_SIX = 6.6;
+    public const CONST_ONE = "ONE";
+    public const CONST_TWO = 2;
+    public const CONST_THEE = true;
+    public const CONST_FOUR = false;
+    public const CONST_FIVE = "";
+    public const CONST_SIX = 6.6;
 }

--- a/tests/files_expected/enum_objects/WithConstantEnumObject.php
+++ b/tests/files_expected/enum_objects/WithConstantEnumObject.php
@@ -6,5 +6,5 @@ use GraphQL\SchemaObject\EnumObject;
 
 class WithConstantEnumObject extends EnumObject
 {
-    const FIXED_VALUE = "fixed_value";
+    public const FIXED_VALUE = "fixed_value";
 }

--- a/tests/files_expected/enum_objects/WithMultipleConstantsEnumObject.php
+++ b/tests/files_expected/enum_objects/WithMultipleConstantsEnumObject.php
@@ -6,7 +6,7 @@ use GraphQL\SchemaObject\EnumObject;
 
 class WithMultipleConstantsEnumObject extends EnumObject
 {
-    const SOME_VALUE = "some_value";
-    const ANOTHER_VALUE = "another_value";
-    const ONEMOREVALUE = "oneMoreValue";
+    public const SOME_VALUE = "some_value";
+    public const ANOTHER_VALUE = "another_value";
+    public const ONEMOREVALUE = "oneMoreValue";
 }

--- a/tests/files_expected/input_objects/WithEnumValueInputObject.php
+++ b/tests/files_expected/input_objects/WithEnumValueInputObject.php
@@ -8,7 +8,7 @@ class WithEnumValueInputObject extends InputObject
 {
     protected $enumVal;
 
-    public function setEnumVal($enumVal)
+    public function setEnumVal($enumVal): self
     {
         $this->enumVal = $enumVal;
 

--- a/tests/files_expected/input_objects/WithInputObjectValueInputObject.php
+++ b/tests/files_expected/input_objects/WithInputObjectValueInputObject.php
@@ -8,7 +8,7 @@ class WithInputObjectValueInputObject extends InputObject
 {
     protected $inputObject;
 
-    public function setInputObject(WithListValueInputObject $withListValueInputObject)
+    public function setInputObject(WithListValueInputObject $withListValueInputObject): self
     {
         $this->inputObject = $withListValueInputObject;
 

--- a/tests/files_expected/input_objects/WithListValueInputObject.php
+++ b/tests/files_expected/input_objects/WithListValueInputObject.php
@@ -8,7 +8,7 @@ class WithListValueInputObject extends InputObject
 {
     protected $listOne;
 
-    public function setListOne(array $listOne)
+    public function setListOne(array $listOne): self
     {
         $this->listOne = $listOne;
 

--- a/tests/files_expected/input_objects/WithMultipleInputObjectValuesInputObject.php
+++ b/tests/files_expected/input_objects/WithMultipleInputObjectValuesInputObject.php
@@ -9,14 +9,14 @@ class WithMultipleInputObjectValuesInputObject extends InputObject
     protected $inputObject;
     protected $inputObjectTwo;
 
-    public function setInputObject(WithListValueInputObject $withListValueInputObject)
+    public function setInputObject(WithListValueInputObject $withListValueInputObject): self
     {
         $this->inputObject = $withListValueInputObject;
 
         return $this;
     }
 
-    public function setInputObjectTwo(_TestFilterInputObject $testFilterInputObject)
+    public function setInputObjectTwo(_TestFilterInputObject $testFilterInputObject): self
     {
         $this->inputObjectTwo = $testFilterInputObject;
 

--- a/tests/files_expected/input_objects/WithMultipleListValuesInputObject.php
+++ b/tests/files_expected/input_objects/WithMultipleListValuesInputObject.php
@@ -9,14 +9,14 @@ class WithMultipleListValuesInputObject extends InputObject
     protected $listOne;
     protected $list_two;
 
-    public function setListOne(array $listOne)
+    public function setListOne(array $listOne): self
     {
         $this->listOne = $listOne;
 
         return $this;
     }
 
-    public function setListTwo(array $listTwo)
+    public function setListTwo(array $listTwo): self
     {
         $this->list_two = $listTwo;
 

--- a/tests/files_expected/input_objects/WithMultipleScalarValuesInputObject.php
+++ b/tests/files_expected/input_objects/WithMultipleScalarValuesInputObject.php
@@ -9,14 +9,14 @@ class WithMultipleScalarValuesInputObject extends InputObject
     protected $valOne;
     protected $val_two;
 
-    public function setValOne($valOne)
+    public function setValOne($valOne): self
     {
         $this->valOne = $valOne;
 
         return $this;
     }
 
-    public function setValTwo($valTwo)
+    public function setValTwo($valTwo): self
     {
         $this->val_two = $valTwo;
 

--- a/tests/files_expected/input_objects/WithScalarValueInputObject.php
+++ b/tests/files_expected/input_objects/WithScalarValueInputObject.php
@@ -8,7 +8,7 @@ class WithScalarValueInputObject extends InputObject
 {
     protected $valOne;
 
-    public function setValOne($valOne)
+    public function setValOne($valOne): self
     {
         $this->valOne = $valOne;
 

--- a/tests/files_expected/input_objects/_TestFilterInputObject.php
+++ b/tests/files_expected/input_objects/_TestFilterInputObject.php
@@ -11,28 +11,28 @@ class _TestFilterInputObject extends InputObject
     protected $ids;
     protected $testFilter;
 
-    public function setFirstName($firstName)
+    public function setFirstName($firstName): self
     {
         $this->first_name = $firstName;
 
         return $this;
     }
 
-    public function setLastName($lastName)
+    public function setLastName($lastName): self
     {
         $this->lastName = $lastName;
 
         return $this;
     }
 
-    public function setIds(array $ids)
+    public function setIds(array $ids): self
     {
         $this->ids = $ids;
 
         return $this;
     }
 
-    public function setTestFilter(_TestFilterInputObject $testFilterInputObject)
+    public function setTestFilter(_TestFilterInputObject $testFilterInputObject): self
     {
         $this->testFilter = $testFilterInputObject;
 

--- a/tests/files_expected/interface_objects/InterfaceObject1QueryObject.php
+++ b/tests/files_expected/interface_objects/InterfaceObject1QueryObject.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace GraphQL\Tests\SchemaObject;
+
+use GraphQL\SchemaObject\QueryObject;
+
+class InterfaceObject1QueryObject extends QueryObject
+{
+    const OBJECT_NAME = "InterfaceObject1";
+
+    public function selectValue()
+    {
+        $this->selectField("value");
+
+        return $this;
+    }
+}

--- a/tests/files_expected/interface_objects/InterfaceObject1QueryObject.php
+++ b/tests/files_expected/interface_objects/InterfaceObject1QueryObject.php
@@ -8,7 +8,7 @@ class InterfaceObject1QueryObject extends QueryObject
 {
     const OBJECT_NAME = "InterfaceObject1";
 
-    public function selectValue()
+    public function selectValue(): self
     {
         $this->selectField("value");
 

--- a/tests/files_expected/interface_objects/InterfaceObject1QueryObject.php
+++ b/tests/files_expected/interface_objects/InterfaceObject1QueryObject.php
@@ -6,7 +6,7 @@ use GraphQL\SchemaObject\QueryObject;
 
 class InterfaceObject1QueryObject extends QueryObject
 {
-    const OBJECT_NAME = "InterfaceObject1";
+    public const OBJECT_NAME = "InterfaceObject1";
 
     public function selectValue(): self
     {

--- a/tests/files_expected/interface_objects/InterfaceObject2QueryObject.php
+++ b/tests/files_expected/interface_objects/InterfaceObject2QueryObject.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace GraphQL\Tests\SchemaObject;
+
+use GraphQL\SchemaObject\QueryObject;
+
+class InterfaceObject2QueryObject extends QueryObject
+{
+    const OBJECT_NAME = "InterfaceObject2";
+}

--- a/tests/files_expected/interface_objects/InterfaceObject2QueryObject.php
+++ b/tests/files_expected/interface_objects/InterfaceObject2QueryObject.php
@@ -6,5 +6,5 @@ use GraphQL\SchemaObject\QueryObject;
 
 class InterfaceObject2QueryObject extends QueryObject
 {
-    const OBJECT_NAME = "InterfaceObject2";
+    public const OBJECT_NAME = "InterfaceObject2";
 }

--- a/tests/files_expected/interface_objects/TestInterfaceQueryObject.php
+++ b/tests/files_expected/interface_objects/TestInterfaceQueryObject.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace GraphQL\Tests\SchemaObject;
+
+use GraphQL\SchemaObject\InterfaceObject;
+
+class TestInterfaceQueryObject extends InterfaceObject
+{
+    public function onInterfaceObject1(): InterfaceObject1QueryObject
+    {
+        return $this->addImplementation(InterfaceObject1QueryObject::class);
+    }
+
+    public function onInterfaceObject2(): InterfaceObject2QueryObject
+    {
+        return $this->addImplementation(InterfaceObject2QueryObject::class);
+    }
+
+    public function selectInterfaceField()
+    {
+        $this->selectField("interface_field");
+
+        return $this;
+    }
+}

--- a/tests/files_expected/interface_objects/TestInterfaceQueryObject.php
+++ b/tests/files_expected/interface_objects/TestInterfaceQueryObject.php
@@ -16,7 +16,7 @@ class TestInterfaceQueryObject extends InterfaceObject
         return $this->addImplementation(InterfaceObject2QueryObject::class);
     }
 
-    public function selectInterfaceField()
+    public function selectInterfaceField(): self
     {
         $this->selectField("interface_field");
 

--- a/tests/files_expected/mutation_objects/RootMutationObject.php
+++ b/tests/files_expected/mutation_objects/RootMutationObject.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace GraphQL\Tests\SchemaObject;
+
+use GraphQL\SchemaObject\QueryObject;
+use GraphQL\Mutation;
+
+class RootMutationObject extends QueryObject
+{
+    const OBJECT_NAME = "";
+
+    public function __construct()
+    {
+        parent::__construct();
+        $this->query = new Mutation();
+    }
+}

--- a/tests/files_expected/mutation_objects/RootMutationObject.php
+++ b/tests/files_expected/mutation_objects/RootMutationObject.php
@@ -7,7 +7,7 @@ use GraphQL\Mutation;
 
 class RootMutationObject extends QueryObject
 {
-    const OBJECT_NAME = "";
+    public const OBJECT_NAME = "";
 
     public function __construct()
     {

--- a/tests/files_expected/query_objects/EmptyQueryObject.php
+++ b/tests/files_expected/query_objects/EmptyQueryObject.php
@@ -6,5 +6,5 @@ use GraphQL\SchemaObject\QueryObject;
 
 class EmptyQueryObject extends QueryObject
 {
-    const OBJECT_NAME = "Empty";
+    public const OBJECT_NAME = "Empty";
 }

--- a/tests/files_expected/query_objects/MultipleObjectSelectorsQueryObject.php
+++ b/tests/files_expected/query_objects/MultipleObjectSelectorsQueryObject.php
@@ -8,12 +8,9 @@ class MultipleObjectSelectorsQueryObject extends QueryObject
 {
     const OBJECT_NAME = "MultipleObjectSelectors";
 
-    public function selectRight(MultipleObjectSelectorsRightArgumentsObject $argsObject = null)
+    public function selectRight()
     {
         $object = new MultipleObjectSelectorsRightQueryObject("right");
-        if ($argsObject !== null) {
-            $object->appendArguments($argsObject->toArray());
-        }
         $this->selectField($object);
 
         return $object;
@@ -22,12 +19,9 @@ class MultipleObjectSelectorsQueryObject extends QueryObject
     /**
      * @deprecated
      */
-    public function selectLeftObjects(MultipleObjectSelectorsLeftObjectsArgumentsObject $argsObject = null)
+    public function selectLeftObjects()
     {
         $object = new LeftQueryObject("left_objects");
-        if ($argsObject !== null) {
-            $object->appendArguments($argsObject->toArray());
-        }
         $this->selectField($object);
 
         return $object;

--- a/tests/files_expected/query_objects/MultipleObjectSelectorsQueryObject.php
+++ b/tests/files_expected/query_objects/MultipleObjectSelectorsQueryObject.php
@@ -6,7 +6,7 @@ use GraphQL\SchemaObject\QueryObject;
 
 class MultipleObjectSelectorsQueryObject extends QueryObject
 {
-    const OBJECT_NAME = "MultipleObjectSelectors";
+    public const OBJECT_NAME = "MultipleObjectSelectors";
 
     public function selectRight(): MultipleObjectSelectorsRightQueryObject
     {

--- a/tests/files_expected/query_objects/MultipleObjectSelectorsQueryObject.php
+++ b/tests/files_expected/query_objects/MultipleObjectSelectorsQueryObject.php
@@ -8,7 +8,7 @@ class MultipleObjectSelectorsQueryObject extends QueryObject
 {
     const OBJECT_NAME = "MultipleObjectSelectors";
 
-    public function selectRight()
+    public function selectRight(): MultipleObjectSelectorsRightQueryObject
     {
         $object = new MultipleObjectSelectorsRightQueryObject("right");
         $this->selectField($object);
@@ -19,7 +19,7 @@ class MultipleObjectSelectorsQueryObject extends QueryObject
     /**
      * @deprecated
      */
-    public function selectLeftObjects()
+    public function selectLeftObjects(): LeftQueryObject
     {
         $object = new LeftQueryObject("left_objects");
         $this->selectField($object);

--- a/tests/files_expected/query_objects/MultipleSimpleSelectorsQueryObject.php
+++ b/tests/files_expected/query_objects/MultipleSimpleSelectorsQueryObject.php
@@ -8,7 +8,7 @@ class MultipleSimpleSelectorsQueryObject extends QueryObject
 {
     const OBJECT_NAME = "MultipleSimpleSelectors";
 
-    public function selectFirstName()
+    public function selectFirstName(): self
     {
         $this->selectField("first_name");
 
@@ -18,14 +18,14 @@ class MultipleSimpleSelectorsQueryObject extends QueryObject
     /**
      * @deprecated is deprecated
      */
-    public function selectLastName()
+    public function selectLastName(): self
     {
         $this->selectField("last_name");
 
         return $this;
     }
 
-    public function selectGender()
+    public function selectGender(): self
     {
         $this->selectField("gender");
 

--- a/tests/files_expected/query_objects/MultipleSimpleSelectorsQueryObject.php
+++ b/tests/files_expected/query_objects/MultipleSimpleSelectorsQueryObject.php
@@ -6,7 +6,7 @@ use GraphQL\SchemaObject\QueryObject;
 
 class MultipleSimpleSelectorsQueryObject extends QueryObject
 {
-    const OBJECT_NAME = "MultipleSimpleSelectors";
+    public const OBJECT_NAME = "MultipleSimpleSelectors";
 
     public function selectFirstName(): self
     {

--- a/tests/files_expected/query_objects/ObjectSelectorQueryObject.php
+++ b/tests/files_expected/query_objects/ObjectSelectorQueryObject.php
@@ -6,7 +6,7 @@ use GraphQL\SchemaObject\QueryObject;
 
 class ObjectSelectorQueryObject extends QueryObject
 {
-    const OBJECT_NAME = "ObjectSelector";
+    public const OBJECT_NAME = "ObjectSelector";
 
     public function selectOthers(?RootOthersArgumentsObject $argsObject = null): OtherQueryObject
     {

--- a/tests/files_expected/query_objects/ObjectSelectorQueryObject.php
+++ b/tests/files_expected/query_objects/ObjectSelectorQueryObject.php
@@ -8,7 +8,7 @@ class ObjectSelectorQueryObject extends QueryObject
 {
     const OBJECT_NAME = "ObjectSelector";
 
-    public function selectOthers(?RootOthersArgumentsObject $argsObject = null)
+    public function selectOthers(?RootOthersArgumentsObject $argsObject = null): OtherQueryObject
     {
         $object = new OtherQueryObject("others");
         if ($argsObject !== null) {

--- a/tests/files_expected/query_objects/ObjectSelectorQueryObject.php
+++ b/tests/files_expected/query_objects/ObjectSelectorQueryObject.php
@@ -8,7 +8,7 @@ class ObjectSelectorQueryObject extends QueryObject
 {
     const OBJECT_NAME = "ObjectSelector";
 
-    public function selectOthers(RootOthersArgumentsObject $argsObject = null)
+    public function selectOthers(?RootOthersArgumentsObject $argsObject = null)
     {
         $object = new OtherQueryObject("others");
         if ($argsObject !== null) {

--- a/tests/files_expected/query_objects/RootQueryObject.php
+++ b/tests/files_expected/query_objects/RootQueryObject.php
@@ -6,5 +6,5 @@ use GraphQL\SchemaObject\QueryObject;
 
 class RootQueryObject extends QueryObject
 {
-    const OBJECT_NAME = "";
+    public const OBJECT_NAME = "";
 }

--- a/tests/files_expected/query_objects/SimpleSelectorQueryObject.php
+++ b/tests/files_expected/query_objects/SimpleSelectorQueryObject.php
@@ -8,7 +8,7 @@ class SimpleSelectorQueryObject extends QueryObject
 {
     const OBJECT_NAME = "SimpleSelector";
 
-    public function selectName()
+    public function selectName(): self
     {
         $this->selectField("name");
 

--- a/tests/files_expected/query_objects/SimpleSelectorQueryObject.php
+++ b/tests/files_expected/query_objects/SimpleSelectorQueryObject.php
@@ -6,7 +6,7 @@ use GraphQL\SchemaObject\QueryObject;
 
 class SimpleSelectorQueryObject extends QueryObject
 {
-    const OBJECT_NAME = "SimpleSelector";
+    public const OBJECT_NAME = "SimpleSelector";
 
     public function selectName(): self
     {

--- a/tests/files_expected/union_objects/UnionObject1QueryObject.php
+++ b/tests/files_expected/union_objects/UnionObject1QueryObject.php
@@ -8,12 +8,9 @@ class UnionObject1QueryObject extends QueryObject
 {
     const OBJECT_NAME = "UnionObject1";
 
-    public function selectUnion(UnionObject1UnionArgumentsObject $argsObject = null)
+    public function selectUnion()
     {
         $object = new UnionTestObjectUnionObject("union");
-        if ($argsObject !== null) {
-            $object->appendArguments($argsObject->toArray());
-        }
         $this->selectField($object);
 
         return $object;

--- a/tests/files_expected/union_objects/UnionObject1QueryObject.php
+++ b/tests/files_expected/union_objects/UnionObject1QueryObject.php
@@ -8,7 +8,7 @@ class UnionObject1QueryObject extends QueryObject
 {
     const OBJECT_NAME = "UnionObject1";
 
-    public function selectUnion()
+    public function selectUnion(): UnionTestObjectUnionObject
     {
         $object = new UnionTestObjectUnionObject("union");
         $this->selectField($object);

--- a/tests/files_expected/union_objects/UnionObject1QueryObject.php
+++ b/tests/files_expected/union_objects/UnionObject1QueryObject.php
@@ -6,7 +6,7 @@ use GraphQL\SchemaObject\QueryObject;
 
 class UnionObject1QueryObject extends QueryObject
 {
-    const OBJECT_NAME = "UnionObject1";
+    public const OBJECT_NAME = "UnionObject1";
 
     public function selectUnion(): UnionTestObjectUnionObject
     {

--- a/tests/files_expected/union_objects/UnionObject2QueryObject.php
+++ b/tests/files_expected/union_objects/UnionObject2QueryObject.php
@@ -6,5 +6,5 @@ use GraphQL\SchemaObject\QueryObject;
 
 class UnionObject2QueryObject extends QueryObject
 {
-    const OBJECT_NAME = "UnionObject2";
+    public const OBJECT_NAME = "UnionObject2";
 }

--- a/tests/files_expected/union_objects/UnionTestObjectUnionObject.php
+++ b/tests/files_expected/union_objects/UnionTestObjectUnionObject.php
@@ -6,7 +6,7 @@ use GraphQL\SchemaObject\UnionObject;
 
 class UnionTestObjectUnionObject extends UnionObject
 {
-    public function onUnionObject1()
+    public function onUnionObject1(): UnionObject1QueryObject
     {
         $object = new UnionObject1QueryObject();
         $this->addPossibleType($object);
@@ -14,7 +14,7 @@ class UnionTestObjectUnionObject extends UnionObject
         return $object;
     }
 
-    public function onUnionObject2()
+    public function onUnionObject2(): UnionObject2QueryObject
     {
         $object = new UnionObject2QueryObject();
         $this->addPossibleType($object);


### PR DESCRIPTION
I have a fairly large API and as such a lot of PHP files are generated by the OQM code generator.

Most of the field in my schema have no arguments, but right now the OQM generates an empty `ArgumentsObject` class for each object field.

This PR enhances the code generator so an ArgumentsObject is only generated when a field accepts arguments.